### PR TITLE
Add log rotation to docker

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,7 +16,7 @@ query:
 json-rpc-proxy:
   jsonRpcImage: "openzeppelin/fortify-json-rpc:latest"
   ethereum:
-    jsonRpcUrl: "https://eth-mainnet.alchemyapi.io/v2/buJLG95oaeuw0XaC0ZYXYHdDs4pOSSTe"
+    jsonRpcUrl: "http://eth.fortify-dev.com:8545"
 
 agents:
   - name: "example-agent"
@@ -28,3 +28,5 @@ agents:
 
 log:
   level: debug
+  maxLogSize: 10m
+  maxLogFiles: 10

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,12 @@ type JsonRpcProxyConfig struct {
 	Ethereum     EthereumConfig `yaml:"ethereum" json:"ethereum"`
 }
 
+type LogConfig struct {
+	Level       string `yaml:"level" json:"level"`
+	MaxLogSize  string `yaml:"maxLogSize" json:"maxLogSize"`
+	MaxLogFiles int    `yaml:"maxLogFiles" json:"maxLogFiles"`
+}
+
 func (ac AgentConfig) ContainerName() string {
 	return fmt.Sprintf("%s-agent-%s", FortifyPrefix, ac.Name)
 }
@@ -62,9 +68,7 @@ type Config struct {
 	Query        QueryConfig        `yaml:"query" json:"query"`
 	JsonRpcProxy JsonRpcProxyConfig `yaml:"json-rpc-proxy" json:"jsonRpcProxy"`
 	Agents       []AgentConfig      `yaml:"agents" json:"agents"`
-	Log          struct {
-		Level string `yaml:"level" json:"level"`
-	} `yaml:"log" json:"log"`
+	Log          LogConfig          `yaml:"log" json:"log"`
 }
 
 func GetFortifyCfgDir() (string, error) {

--- a/services/containers/tx_node.go
+++ b/services/containers/tx_node.go
@@ -39,6 +39,9 @@ func (t *TxNodeService) Start() error {
 		return err
 	}
 
+	maxLogSize := t.config.Config.Log.MaxLogSize
+	maxLogFiles := t.config.Config.Log.MaxLogFiles
+
 	cfgBytes, err := json.Marshal(t.config.Config)
 	if err != nil {
 		log.Error("cannot marshal config to json", err)
@@ -71,6 +74,8 @@ func (t *TxNodeService) Start() error {
 				config.EnvJsonRpcHost: jsonRpcProxyName,
 				config.EnvJsonRpcPort: "8545",
 			},
+			MaxLogFiles: maxLogFiles,
+			MaxLogSize:  maxLogSize,
 		})
 		if err != nil {
 			return err
@@ -93,7 +98,9 @@ func (t *TxNodeService) Start() error {
 		Volumes: map[string]string{
 			t.config.Config.Query.DB.Path: store.DBPath,
 		},
-		NetworkID: nodeNetwork,
+		NetworkID:   nodeNetwork,
+		MaxLogFiles: maxLogFiles,
+		MaxLogSize:  maxLogSize,
 	})
 	if err != nil {
 		return err
@@ -107,6 +114,8 @@ func (t *TxNodeService) Start() error {
 		},
 		NetworkID:      nodeNetwork,
 		LinkNetworkIDs: networkIDs,
+		MaxLogFiles:    maxLogFiles,
+		MaxLogSize:     maxLogSize,
 	})
 	if err != nil {
 		return err
@@ -132,6 +141,8 @@ func (t *TxNodeService) Start() error {
 		},
 		NetworkID:      nodeNetwork,
 		LinkNetworkIDs: networkIDs,
+		MaxLogFiles:    maxLogFiles,
+		MaxLogSize:     maxLogSize,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This makes the logging per container configurable.  Currently it includes a max size per file and number of log files.  (see https://docs.docker.com/config/containers/logging/json-file/)

Example Config (from config.yml):
```yaml
log:
  level: debug
  maxLogSize: 10m
  maxLogFiles: 10
```


Fixes #2 