### PR TITLE
Add alertID to finding result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ main:
 	docker create --name build-fortify build-fortify
 	docker cp build-fortify:/main fortify
 	docker rm -f build-fortify
+	chmod 755 fortify
 
 proto:
 	protoc -I=protocol --go-grpc_out=protocol/. --go_out=protocol/. protocol/agent.proto

--- a/config-dev.yml
+++ b/config-dev.yml
@@ -23,7 +23,7 @@ json-rpc-proxy:
 agents:
   - name: "example-agent"
     image: "openzeppelin/fortify-agent:latest"
-    imageHash: "sha256:d2edd2040544eba5c46f539b45684742bf71f010067469e588af2b8e90ddacdd"
+    imageHash: "sha256:567a1190b892fc8d46ec464c5dd6bba7967a608616867f575373d643b90bddfb"
 
 log:
   level: info

--- a/config.yml
+++ b/config.yml
@@ -21,7 +21,7 @@ json-rpc-proxy:
 agents:
   - name: "example-agent"
     image: "openzeppelin/fortify-agent:latest"
-    imageHash: "sha256:db7de781be9b7d6d2a217078e7082d7fe4a0d69b165d5d25f4d458952b7ec5b0"
+    imageHash: "sha256:2c1304243b69a7daea49d5b62b9a4b589b5378299c9f9ffb62ba12178f425787"
 #  - name: "flash-loans"
 #    image: "openzeppelin/lab-flash-loans:latest"
 #    imageHash: "sha256:b33c53cbbf29faa3511d4e339288e3d86d290771535d3dcd15f8ba23d7c91a99"

--- a/protocol/agent.proto
+++ b/protocol/agent.proto
@@ -60,6 +60,7 @@ message Finding {
   Severity severity = 2;
   map<string, string> metadata = 3;
   FindingType type = 4;
+  string alertId = 5;
 }
 
 message EvaluateTxResponse {

--- a/store/alerts.go
+++ b/store/alerts.go
@@ -30,6 +30,9 @@ type FilterCriterion struct {
 }
 
 func stringVal(fieldName string, alert *protocol.Alert) (string, bool) {
+	if fieldName == "alertId" {
+		return alert.Finding.AlertId, true
+	}
 	if fieldName == "severity" {
 		return alert.Finding.Severity.String(), true
 	}


### PR DESCRIPTION
- AlertID is a reference to an identifier for the specific alert 
- The agent decides which AlertIDs it emits
- Future: AlertIDs should be registered and described (somewhere) so that the UI can tell the user what the alert means.

Results look like this:
```json
{
	"alerts": [{
		"alert": {
			"id": "87qdTrXRjanoHfU8JjsFLscPh4r7LYT1oEnXrVUnT6UPLm57Sbu6eYL25BKvLBhTk83wNnHe5mzT6LMW2mq8X9DzQT5TFHoL6en1k3aAA4qLmtmXWWt6bsktHWuuJvGf9NwvtHVxUHydoSbhgVXUEeaZjVLeMvqPRdPZ2pc9Mgw2boTv8pYnP9wsGBaYEtAMbCTaWyo7vgzshrrHVcu4wtCjUZGuXbTUxZS5nuZTPFw",
			"type": "TRANSACTION",
			"finding": {
				"protocol": "test-protocol",
				"severity": "CRITICAL",
				"metadata": {
					"balance": "0",
					"risk": "0.999452296916896"
				},
				"type": "EXPLOIT",
				"alertId": "FORTIFY-1"
			},
			"timestamp": "2021-06-04T15:52:30.015543589Z",
			"metadata": {},
			"agent": {
				"image": "openzeppelin/fortify-agent:latest",
				"imageHash": "sha256:2c1304243b69a7daea49d5b62b9a4b589b5378299c9f9ffb62ba12178f425787",
				"name": "example-agent"
			},
			"tags": {
				"blockHash": "0x04a762127295a62e0ed4676c263d9dceb166798d6458aa12d6178e2148c9185c",
				"blockNumber": "0x3cac3a",
				"chainId": "0x1",
				"txHash": "0x4184c976e3721c44bee9b1345b3a78e45ca03c11b14aefa3a6f605716e670093"
			},
			"scanner": {
				"address": "0x11d425cBFa2CA005Aa3E3f5A3F5AF789f27C1DFf"
			}
		},
		"signature": {
			"signature": "0xbc6d4d32edefd9b634ff1725df999e7f79402a27a21f055c1f10c1e693a95bc57d51b3620af1e260acd4d3edf3e35641b8138c59eed620d0ad133f584fc08ac000",
			"algorithm": "ECDSA"
		}
	}],
	"nextPageToken": ""
}
```