### PR TITLE
Add name and description to finding

### DIFF
--- a/protocol/agent.proto
+++ b/protocol/agent.proto
@@ -63,6 +63,8 @@ message Finding {
   map<string, string> metadata = 3;
   FindingType type = 4;
   string alertId = 5;
+  string name = 6;
+  string description = 7;
 }
 
 message EvaluateTxResponse {


### PR DESCRIPTION
- Name represents the name of the alert like "High Gas Price" (at some point will be cross referenced by alert ID)
- Description is a human readable text that will be shown in the dApp table where details are today  (High gas of 8322 was found)