### PR TITLE
Retry healthcheck for race condition on new agent loading

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,9 +1,27 @@
 package utils
 
+import "time"
+
 // ShortenString shortens the string if the string is longer than given length.
 func ShortenString(str string, maxLength int) string {
 	if len(str) <= maxLength {
 		return str
 	}
 	return str[:maxLength]
+}
+
+// TryTimes will try an action up to `times` times with a delay of `delay` between each attempt
+func TryTimes(handler func() error, times int, delay time.Duration) error {
+	var result error
+	ticker := time.NewTicker(delay)
+	defer ticker.Stop()
+	for i := 0; i < times; i++ {
+		if err := handler(); err == nil {
+			return nil
+		} else {
+			result = err
+		}
+		<-ticker.C
+	}
+	return result
 }


### PR DESCRIPTION
- it seems to panic when it loads a new agent because it's not quite available yet
- this might be exacerbated by the size of the image