### PR TITLE
Add everest ID to finding protocol

### DIFF
--- a/protocol/agent.proto
+++ b/protocol/agent.proto
@@ -65,6 +65,7 @@ message Finding {
   string alertId = 5;
   string name = 6;
   string description = 7;
+  string everestId = 8;
 }
 
 message EvaluateTxResponse {


### PR DESCRIPTION
- everestId refers to the ID in projects on everest.link
- example: (aave) https://everest.link/project/0xa3d1fd85c0b62fa8bab6b818ffc96b5ec57602b6