### PR TITLE
Fail block feed initialization if we get zero block number in success response

### DIFF
--- a/feeds/blocks.go
+++ b/feeds/blocks.go
@@ -3,6 +3,7 @@ package feeds
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	log "github.com/sirupsen/logrus"
@@ -50,6 +51,11 @@ func (bf *blockFeed) initialize() error {
 		if err != nil {
 			log.Errorf("error converting blocknum hex to bigint: %s", err.Error())
 			return nil
+		}
+
+		// should be a positive number
+		if bf.start.Sign() <= 0 {
+			return fmt.Errorf("got invalid block number during initialization: %d", bf.start.Uint64())
 		}
 	}
 	log.Infof("initialized block number %d", bf.start)


### PR DESCRIPTION
Failing the initialization will cause the scanner to be safely restarted and initialized again.

For avoiding this bug, which puts Forta scanner container in a long retry (and a dead end) because of bad initialization:
```
time="2021-08-31T21:24:11Z" level=info msg="Starting scanner"
time="2021-08-31T21:24:11Z" level=info msg="connecting to: forta-nats:4222" name=scanner/messaging nats="forta-nats:4222"
time="2021-08-31T21:24:17Z" level=info msg="initialized block number 0"
time="2021-08-31T21:24:17Z" level=info msg="initialized chainId 1"
time="2021-08-31T21:24:17Z" level=info msg=subscribed name=scanner/messaging nats="forta-nats:4222" subject=agents.versions.latest
time="2021-08-31T21:24:17Z" level=info msg=subscribed name=scanner/messaging nats="forta-nats:4222" subject=agents.status.running
time="2021-08-31T21:24:17Z" level=info msg=subscribed name=scanner/messaging nats="forta-nats:4222" subject=agents.status.stopped
time="2021-08-31T21:24:17Z" level=info msg="Starting BlockAnalyzerService"
time="2021-08-31T21:24:17Z" level=info msg="Starting TxStream"
time="2021-08-31T21:24:17Z" level=info msg="Starting TxAnalyzerService"
time="2021-08-31T21:24:17Z" level=info msg="Starting RegistryService"
time="2021-08-31T21:24:17Z" level=info msg="Creating Caller: RegistryService"
time="2021-08-31T21:24:17Z" level=info msg="registry: agent version changed ->\xe9]\xea\"/\x96s\x13\xeapF\x01\xb8{\x12\x1b2\xb9'9\x9ds\xfd\xf5\x92`\x95\xcf\\J\xa6b"
time="2021-08-31T21:24:17Z" level=info msg="registry: getLatestAgents(0x0A47A59207Be919b84f1864b6a944FC9949166ae) = 17"
time="2021-08-31T21:24:17Z" level=warning msg="trace_block(0) failed...retrying: block 0000000000000000000000000000000000000000000000000000000000000000 not found"
time="2021-08-31T21:24:23Z" level=warning msg="trace_block(0) failed...retrying: block 0000000000000000000000000000000000000000000000000000000000000000 not found"
time="2021-08-31T21:24:29Z" level=warning msg="trace_block(0) failed...retrying: block 0000000000000000000000000000000000000000000000000000000000000000 not found"
time="2021-08-31T21:24:32Z" level=info msg="registry: no agent changes detected"
```

Later on, we see this:
```
time="2021-09-01T10:08:32Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:08:47Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:09:02Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:09:17Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:09:32Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:09:47Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:10:02Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:10:17Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:10:32Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:10:47Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:11:02Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:11:17Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:11:32Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:11:47Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:12:02Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:12:17Z" level=info msg="registry: no agent changes detected"
time="2021-09-01T10:12:32Z" level=info msg="registry: no agent changes detected"
```

This seems to happen because we exit the `forEachBlock()` loop(s) after a while, with `return err`, when all `trace_block` requests fail.