### PR TITLE
Few tweaks to make better use of the latest batch structure

### DIFF
--- a/services/query/query_listener.go
+++ b/services/query/query_listener.go
@@ -237,6 +237,7 @@ func (ab *AlertBatch) AddBatchAgent(agent *protocol.AgentInfo, blockNumber uint6
 	}
 	// There should always be a block number.
 	if blockNumber == 0 {
+		log.Error("zero block number while adding batch agent")
 		return
 	}
 	batchAgent.Blocks = append(batchAgent.Blocks, blockNumber)

--- a/services/scanner/agentpool/agent.go
+++ b/services/scanner/agentpool/agent.go
@@ -67,7 +67,7 @@ func (agent *Agent) processTransactions() {
 		resp, err := agent.client.EvaluateTx(ctx, request)
 		cancel()
 		if err != nil {
-			log.Errorf("error invoking agent: %v", err)
+			log.WithError(err).Error("error invoking agent")
 			continue
 		}
 		log.Debugf("request successful")
@@ -88,7 +88,7 @@ func (agent *Agent) processBlocks() {
 		resp, err := agent.client.EvaluateBlock(ctx, request)
 		cancel()
 		if err != nil {
-			log.Errorf("error invoking agent: %v", err)
+			log.WithError(err).Error("error invoking agent")
 			continue
 		}
 		log.Debugf("request successful")

--- a/services/scanner/block_analyzer.go
+++ b/services/scanner/block_analyzer.go
@@ -99,6 +99,7 @@ func (t *BlockAnalyzerService) Start() error {
 				if err := t.cfg.AlertSender.NotifyWithoutAlert(
 					rt, result.Request.Event.Network.ChainId, result.Request.Event.BlockNumber,
 				); err != nil {
+					log.WithError(err).Error("failed to notify without alert")
 					return err
 				}
 				continue
@@ -112,6 +113,7 @@ func (t *BlockAnalyzerService) Start() error {
 				if err := t.cfg.AlertSender.SignAlertAndNotify(
 					rt, alert, result.Request.Event.Network.ChainId, result.Request.Event.BlockNumber,
 				); err != nil {
+					log.WithError(err).Error("failed sign alert and notify")
 					return err
 				}
 			}

--- a/services/scanner/tx_analyzer.go
+++ b/services/scanner/tx_analyzer.go
@@ -104,6 +104,7 @@ func (t *TxAnalyzerService) Start() error {
 				if err := t.cfg.AlertSender.NotifyWithoutAlert(
 					rt, result.Request.Event.Network.ChainId, result.Request.Event.Block.BlockNumber,
 				); err != nil {
+					log.WithError(err).Error("failed to notify without alert")
 					return err
 				}
 				continue
@@ -118,6 +119,7 @@ func (t *TxAnalyzerService) Start() error {
 				if err := t.cfg.AlertSender.SignAlertAndNotify(
 					rt, alert, result.Request.Event.Network.ChainId, result.Request.Event.Block.BlockNumber,
 				); err != nil {
+					log.WithError(err).Error("failed to sign alert and notify")
 					return err
 				}
 			}


### PR DESCRIPTION
- Notify publisher with empty tx alert results so we can mention in batches that those txs were scanned
- Avoiding unnecessary block and tx result containers in batch, since we mention them separately