### PR TITLE
Extend critical error set with 'unavailable' error

### DIFF
--- a/services/scanner/agentpool/agent.go
+++ b/services/scanner/agentpool/agent.go
@@ -52,7 +52,8 @@ func NewAgent(agentCfg config.AgentConfig, msgClient clients.MessageClient, txRe
 
 func isCriticalErr(err error) bool {
 	errStr := err.Error()
-	return strings.Contains(errStr, codes.DeadlineExceeded.String())
+	return strings.Contains(errStr, codes.DeadlineExceeded.String()) ||
+		strings.Contains(errStr, codes.Unavailable.String())
 }
 
 // Config returns the agent config.


### PR DESCRIPTION
We should stop trying to call the agent if the connections start getting refused for any reason.

```
...
time="2021-09-13T13:08:00Z" level=error msg="error invoking agent" agent=0x1c2a8b3f55d9b444798026ac3672ba436fd9cddbbca9b27b64d0e1b234a2c110 error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 192.168.240.2:50051: connect: connection refused\"" evaluate=transaction
time="2021-09-13T13:08:00Z" level=error msg="error invoking agent" agent=0x1c2a8b3f55d9b444798026ac3672ba436fd9cddbbca9b27b64d0e1b234a2c110 error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 192.168.240.2:50051: connect: connection refused\"" evaluate=transaction
time="2021-09-13T13:08:00Z" level=error msg="error invoking agent" agent=0x1c2a8b3f55d9b444798026ac3672ba436fd9cddbbca9b27b64d0e1b234a2c110 error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 192.168.240.2:50051: connect: connection refused\"" evaluate=transaction
time="2021-09-13T13:08:00Z" level=error msg="error invoking agent" agent=0x1c2a8b3f55d9b444798026ac3672ba436fd9cddbbca9b27b64d0e1b234a2c110 error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 192.168.240.2:50051: connect: connection refused\"" evaluate=transaction
...
```