### PR TITLE
Unblock agent send

### DIFF
--- a/services/scanner/agentpool/agent_pool.go
+++ b/services/scanner/agentpool/agent_pool.go
@@ -83,6 +83,7 @@ func (ap *AgentPool) SendEvaluateTxRequest(req *protocol.EvaluateTxRequest) {
 		case <-agent.Closed():
 			ap.discardAgent(agent)
 		case agent.TxRequestCh() <- req:
+		default: // do not try to send if the buffer is full
 		}
 	}
 	log.WithField("tx", req.Event.Transaction.Hash).Debug("Finished SendEvaluateTxRequest")
@@ -113,6 +114,7 @@ func (ap *AgentPool) SendEvaluateBlockRequest(req *protocol.EvaluateBlockRequest
 		case <-agent.Closed():
 			ap.discardAgent(agent)
 		case agent.BlockRequestCh() <- req:
+		default: // do not try to send if the buffer is full
 		}
 	}
 	log.WithField("block", req.Event.BlockNumber).Debug("Finished SendEvaluateBlockRequest")


### PR DESCRIPTION
If an agent is slow, this lets us not make it other agents' problem.