### PR TITLE
Let scanner dial host so it can reach local geth

### DIFF
--- a/services/supervisor/start.go
+++ b/services/supervisor/start.go
@@ -172,6 +172,7 @@ func (sup *SupervisorService) start() error {
 		Files: map[string][]byte{
 			"passphrase": []byte(sup.config.Passphrase),
 		},
+		DialHost:    true,
 		NetworkID:   nodeNetworkID,
 		MaxLogFiles: sup.maxLogFiles,
 		MaxLogSize:  sup.maxLogSize,


### PR DESCRIPTION
- Let scanner dial host easily.
- Set scan URL in config: `http://host.docker.internal:8545`
- Geth container should be run with flags like: `docker run -p 8545:8545 -it ethereum/client-go --syncmode light --http --http.api eth,net --http.addr 0.0.0.0 --http.vhosts=*`

We should probably add these to scanner docs.