### PR TITLE
Fix prod auto-upgrade workflow: build and store forta bin

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -52,3 +52,42 @@ jobs:
       - name: Publish Hash
         run: |
           ./scripts/publish-release.sh ${{ needs.containers.outputs.node-release-cid }} ${{ secrets.PROD_PUBLISH_AUTOTASK_KEY }} ${{ secrets.PROD_PUBLISH_AUTOTASK_URL }}
+
+  build:
+    name: Build
+    needs: containers
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - name: Echo Image References
+        run: |
+          echo "node=${{ needs.containers.outputs.node-image-ref }}"
+      - name: Clear artifacts
+        uses: kolpav/purge-artifacts-action@v1
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          expire-in: 7days
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Create build for revision
+        run: |
+          ./scripts/build.sh ${{ needs.containers.outputs.node-image-ref }} \
+            'remote' ${{ needs.containers.outputs.node-release-cid }} ${{ github.sha }}
+          chmod 755 forta
+      - name: Configure AWS credentials (build artifact -> S3)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PROD_RELEASE_AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.PROD_RELEASE_AWS_SECRET_KEY }}
+          aws-region: us-east-1
+      - name: Copy build to build artifacts bucket
+        env:
+          BUCKET_NAME: ${{ secrets.PROD_BUILD_ARTIFACTS_BUCKET_NAME }}
+          REVISION: ${{ github.sha }}
+        run: |
+          aws s3 cp forta "s3://$BUCKET_NAME/forta-$REVISION"


### PR DESCRIPTION
Not having this creates a release problem because we don't build the latest binary.