### PR TITLE
Add batch to reference

### DIFF
--- a/domain/alert_batch.go
+++ b/domain/alert_batch.go
@@ -1,11 +1,14 @@
 package domain
 
+import "github.com/forta-protocol/forta-node/protocol"
+
 type AlertBatch struct {
-	Scanner     string `json:"scanner"`
-	ChainID     int64  `json:"chainId"`
-	BlockStart  int64  `json:"blockStart"`
-	BlockEnd    int64  `json:"blockEnd"`
-	AlertCount  int64  `json:"alertCount"`
-	MaxSeverity int64  `json:"maxSeverity"`
-	Ref         string `json:"ref"`
+	Scanner     string                     `json:"scanner"`
+	ChainID     int64                      `json:"chainId"`
+	BlockStart  int64                      `json:"blockStart"`
+	BlockEnd    int64                      `json:"blockEnd"`
+	AlertCount  int64                      `json:"alertCount"`
+	MaxSeverity int64                      `json:"maxSeverity"`
+	Ref         string                     `json:"ref"`
+	SignedBatch *protocol.SignedAlertBatch `json:"signedBatch"`
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/ipfs/go-cid v0.0.7
+	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/klauspost/compress v1.13.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,9 @@ github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19y
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
-github.com/ipfs/go-cid v0.0.7 h1:ysQJVJA3fNDF1qigJbsSQOdjhVLsOEoPdh0+R97k3jY=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
+github.com/ipfs/go-cid v0.1.0 h1:YN33LQulcRHjfom/i25yoOZR4Telp1Hr/2RU3d0PnC0=
+github.com/ipfs/go-cid v0.1.0/go.mod h1:rH5/Xv83Rfy8Rw6xG+id3DYAMUVmem1MowoKwdXmN2o=
 github.com/ipfs/go-ipfs-api v0.2.0 h1:BXRctUU8YOUOQT/jW1s56d9wLa85ntOqK6bptvCKb8c=
 github.com/ipfs/go-ipfs-api v0.2.0/go.mod h1:zCTyTl+BuyvUqoSmVb8vjezCJLVTW7G/HBZbCXpTgeM=
 github.com/ipfs/go-ipfs-files v0.0.8 h1:8o0oFJkJ8UkO/ABl8T6ac6tKF3+NIpj67aAB6ZpusRg=
@@ -710,6 +711,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/services/publisher/publisher.go
+++ b/services/publisher/publisher.go
@@ -163,7 +163,7 @@ func (pub *Publisher) publishNextBatch(batch *protocol.AlertBatch) error {
 		return nil
 	}
 
-	cid, err := pub.ipfs.Add(&buf, ipfsapi.Pin(true))
+	cid, err := pub.ipfs.Add(&buf, ipfsapi.OnlyHash(true))
 	if err != nil {
 		return fmt.Errorf("failed to store alert data to ipfs: %v", err)
 	}
@@ -198,6 +198,7 @@ func (pub *Publisher) publishNextBatch(batch *protocol.AlertBatch) error {
 		AlertCount:  int64(batch.AlertCount),
 		MaxSeverity: int64(batch.MaxSeverity),
 		Ref:         cid,
+		SignedBatch: signedBatch,
 	}, scannerJwt)
 
 	if err != nil {


### PR DESCRIPTION
New Flow:
- IPFS Reference is acquired via 'only hash' property
- Batch goes to alerts api as `signedBatch` property
- API now writes that to S3 (if it's populated)
