### PR TITLE
Add ipfs node for hash calculation

### DIFF
--- a/config/containers.go
+++ b/config/containers.go
@@ -13,10 +13,11 @@ var (
 	DockerUpdaterImage    = "forta-network/forta-node:latest"
 	UseDockerImages       = "local"
 
-	DockerSupervisorManagedContainers = 3
+	DockerSupervisorManagedContainers = 4
 	DockerUpdaterContainerName        = fmt.Sprintf("%s-updater", ContainerNamePrefix)
 	DockerSupervisorContainerName     = fmt.Sprintf("%s-supervisor", ContainerNamePrefix)
 	DockerNatsContainerName           = fmt.Sprintf("%s-nats", ContainerNamePrefix)
+	DockerIpfsContainerName           = fmt.Sprintf("%s-ipfs", ContainerNamePrefix)
 	DockerScannerContainerName        = fmt.Sprintf("%s-scanner", ContainerNamePrefix)
 	DockerJSONRPCProxyContainerName   = fmt.Sprintf("%s-json-rpc", ContainerNamePrefix)
 

--- a/services/publisher/publisher.go
+++ b/services/publisher/publisher.go
@@ -628,7 +628,7 @@ func NewPublisher(ctx context.Context, cfg config.Config) (*Publisher, error) {
 }
 
 func initPublisher(ctx context.Context, mc *messaging.Client, alertClient clients.AlertAPIClient, cfg PublisherConfig) (*Publisher, error) {
-	ipfsClient, err := ipfs.NewClient("http://forta-ipfs:5001")
+	ipfsClient, err := ipfs.NewClient(fmt.Sprintf("http://%s:5001", config.DockerIpfsContainerName))
 	if err != nil {
 		return nil, err
 	}

--- a/services/publisher/publisher.go
+++ b/services/publisher/publisher.go
@@ -628,8 +628,7 @@ func NewPublisher(ctx context.Context, cfg config.Config) (*Publisher, error) {
 }
 
 func initPublisher(ctx context.Context, mc *messaging.Client, alertClient clients.AlertAPIClient, cfg PublisherConfig) (*Publisher, error) {
-
-	ipfsClient, err := ipfs.NewClient(cfg.PublisherConfig.IPFS.APIURL)
+	ipfsClient, err := ipfs.NewClient("http://forta-ipfs:5001")
 	if err != nil {
 		return nil, err
 	}

--- a/services/supervisor/start.go
+++ b/services/supervisor/start.go
@@ -149,18 +149,33 @@ func (sup *SupervisorService) start() error {
 		return fmt.Errorf("failed to attach supervisor container to node network: %v", err)
 	}
 
-	var natsNetworkID string
+	var internalNetworkID string
 	if sup.config.Config.ExposeNats {
-		natsNetworkID = nodeNetworkID
+		internalNetworkID = nodeNetworkID
 	} else {
-		natsNetworkID, err = sup.client.CreateInternalNetwork(sup.ctx, config.DockerNatsContainerName)
+		internalNetworkID, err = sup.client.CreateInternalNetwork(sup.ctx, config.DockerNatsContainerName)
 		if err != nil {
 			return err
 		}
-		if err := sup.client.AttachNetwork(sup.ctx, supervisorContainer.ID, natsNetworkID); err != nil {
+		if err := sup.client.AttachNetwork(sup.ctx, supervisorContainer.ID, internalNetworkID); err != nil {
 			return fmt.Errorf("failed to attach supervisor container to nats network: %v", err)
 		}
 	}
+
+	ipfsContainer, err := sup.client.StartContainer(sup.ctx, clients.DockerContainerConfig{
+		Name:  config.DockerIpfsContainerName,
+		Image: "ipfs/go-ipfs:v0.12.2",
+		Ports: map[string]string{
+			"5001": "5001",
+		},
+		NetworkID:   internalNetworkID,
+		MaxLogFiles: sup.maxLogFiles,
+		MaxLogSize:  sup.maxLogSize,
+	})
+	if err != nil {
+		return err
+	}
+	sup.addContainerUnsafe(ipfsContainer)
 
 	// start nats, wait for it and connect from the supervisor
 	natsContainer, err := sup.client.StartContainer(sup.ctx, clients.DockerContainerConfig{
@@ -171,7 +186,7 @@ func (sup *SupervisorService) start() error {
 			"6222": "6222",
 			"8222": "8222",
 		},
-		NetworkID:   natsNetworkID,
+		NetworkID:   internalNetworkID,
 		MaxLogFiles: sup.maxLogFiles,
 		MaxLogSize:  sup.maxLogSize,
 	})
@@ -238,10 +253,10 @@ func (sup *SupervisorService) start() error {
 	sup.addContainerUnsafe(sup.scannerContainer)
 
 	if !sup.config.Config.ExposeNats {
-		if err := sup.attachToNetwork(config.DockerScannerContainerName, natsNetworkID); err != nil {
+		if err := sup.attachToNetwork(config.DockerScannerContainerName, internalNetworkID); err != nil {
 			return err
 		}
-		if err := sup.attachToNetwork(config.DockerJSONRPCProxyContainerName, natsNetworkID); err != nil {
+		if err := sup.attachToNetwork(config.DockerJSONRPCProxyContainerName, internalNetworkID); err != nil {
 			return err
 		}
 	}
@@ -290,6 +305,7 @@ func (sup *SupervisorService) removeOldContainers() error {
 		config.DockerScannerContainerName,
 		config.DockerJSONRPCProxyContainerName,
 		config.DockerNatsContainerName,
+		config.DockerIpfsContainerName,
 	} {
 		container, err := sup.client.GetContainerByName(sup.ctx, containerName)
 		if err != nil {

--- a/services/supervisor/start_test.go
+++ b/services/supervisor/start_test.go
@@ -104,6 +104,9 @@ func (s *Suite) SetupTest() {
 	s.dockerClient.EXPECT().CreatePublicNetwork(service.ctx, gomock.Any()).Return(testNodeNetworkID, nil)
 	s.dockerClient.EXPECT().CreateInternalNetwork(service.ctx, gomock.Any()).Return(testNatsNetworkID, nil) // for nats
 	s.dockerClient.EXPECT().StartContainer(service.ctx, (configMatcher)(clients.DockerContainerConfig{
+		Name: config.DockerIpfsContainerName,
+	})).Return(&clients.DockerContainer{}, nil)
+	s.dockerClient.EXPECT().StartContainer(service.ctx, (configMatcher)(clients.DockerContainerConfig{
 		Name: config.DockerNatsContainerName,
 	})).Return(&clients.DockerContainer{}, nil)
 	s.dockerClient.EXPECT().StartContainer(service.ctx, (configMatcher)(clients.DockerContainerConfig{
@@ -116,6 +119,7 @@ func (s *Suite) SetupTest() {
 	s.globalClient.EXPECT().GetContainerByName(service.ctx, config.DockerSupervisorContainerName).Return(&types.Container{ID: testSupervisorContainerID}, nil).AnyTimes()
 	s.dockerClient.EXPECT().AttachNetwork(service.ctx, testSupervisorContainerID, testNodeNetworkID)
 	s.dockerClient.EXPECT().AttachNetwork(service.ctx, testSupervisorContainerID, testNatsNetworkID)
+	s.dockerClient.EXPECT().GetContainerByName(service.ctx, config.DockerScannerContainerName).Return(&types.Container{ID: testScannerContainerID}, nil).AnyTimes()
 	s.dockerClient.EXPECT().GetContainerByName(service.ctx, config.DockerScannerContainerName).Return(&types.Container{ID: testScannerContainerID}, nil).AnyTimes()
 	s.dockerClient.EXPECT().AttachNetwork(service.ctx, testScannerContainerID, testNatsNetworkID)
 	s.dockerClient.EXPECT().GetContainerByName(service.ctx, config.DockerJSONRPCProxyContainerName).Return(&types.Container{ID: testProxyContainerID}, nil).AnyTimes()
@@ -133,6 +137,7 @@ func (s *Suite) initialContainerCheck() {
 		config.DockerScannerContainerName,
 		config.DockerJSONRPCProxyContainerName,
 		config.DockerNatsContainerName,
+		config.DockerIpfsContainerName,
 	} {
 		s.dockerClient.EXPECT().GetContainerByName(s.service.ctx, containerName).Return(&types.Container{ID: testGenericContainerID}, nil)
 	}


### PR DESCRIPTION
- Adds IPFS container locally to avoid doing a remote webrequest on only_hash=true lookup for CID calculations