### PR TITLE
Randomize update interval at startup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,7 @@ type TelemetryConfig struct {
 
 type AutoUpdateConfig struct {
 	Disable              bool `yaml:"disable" json:"disable"`
-	CheckIntervalSeconds int  `yaml:"checkIntervalSeconds" json:"checkIntervalSeconds" default:"60"`
+	CheckIntervalSeconds *int `yaml:"checkIntervalSeconds" json:"checkIntervalSeconds" default:"60"`
 }
 
 type AgentLogsConfig struct {


### PR DESCRIPTION
- If we release nodes, currently all nodes update within 1 minute which causes a moment where all of forta is restarting
- This change allows us to randomly distribute update times across a 6 hour period so that bots are always up