### PR TITLE
Fix local mode block range and timeout bugs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -109,7 +109,7 @@ type ContainerRegistryConfig struct {
 type RuntimeLimits struct {
 	StartBlock         uint64 `yaml:"startBlock" json:"startBlock"`
 	StopBlock          uint64 `yaml:"stopBlock" json:"stopBlock" validate:"omitempty,gtfield=StartBlock"`
-	StopTimeoutSeconds int    `yaml:"stopTimeoutSeconds" json:"stopTimeoutSeconds" default:"10"`
+	StopTimeoutSeconds int    `yaml:"stopTimeoutSeconds" json:"stopTimeoutSeconds" default:"30"`
 }
 
 type LocalModeConfig struct {

--- a/services/publisher/publisher.go
+++ b/services/publisher/publisher.go
@@ -591,13 +591,6 @@ func (pub *Publisher) Start() error {
 }
 
 func (pub *Publisher) Stop() error {
-	cfg := pub.cfg.Config
-	if cfg.LocalModeConfig.Enable {
-		timeoutSeconds := cfg.LocalModeConfig.RuntimeLimits.StopTimeoutSeconds
-		log.WithField("timeout", fmt.Sprintf("%ds", timeoutSeconds)).Info("waiting for scanning to finish")
-		time.Sleep(time.Duration(timeoutSeconds) * time.Second)
-		log.WithField("timeout", fmt.Sprintf("%ds", timeoutSeconds)).Info("done waiting scanning to finish")
-	}
 	if pub.server != nil {
 		pub.server.Stop()
 	}

--- a/services/publisher/webhooklog/logger.go
+++ b/services/publisher/webhooklog/logger.go
@@ -31,6 +31,8 @@ func NewLogger(logFileName string) (*Logger, error) {
 	}
 
 	fullPath := path.Join(logsDir, fileName)
+	log.WithField("file", fullPath).Info("logging local alerts and metrics")
+
 	file, err := os.Create(fullPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the webhook log file: %v", err)

--- a/services/runner/runner.go
+++ b/services/runner/runner.go
@@ -369,7 +369,7 @@ func (runner *Runner) doKeepContainersAlive() error {
 			}
 			if containerDetails.State.ExitCode == services.ExitCodeTriggered {
 				log.WithField("name", runner.supervisorContainer.Name).Info("detected internal exit trigger - exiting")
-				services.TriggerExit()
+				services.TriggerExit(0)
 				return nil
 			}
 			runner.dockerClient.StartContainer(runner.ctx, runner.supervisorContainer.Config)

--- a/services/service.go
+++ b/services/service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -130,7 +131,12 @@ func InterruptMainContext() {
 }
 
 // TriggerExit triggers exit internally.
-func TriggerExit() {
+func TriggerExit(delay time.Duration) {
+	if delay > 0 {
+		log.WithField("timeout", fmt.Sprintf("%s", delay)).Info("waiting before triggering exit")
+		time.Sleep(delay)
+		log.WithField("timeout", fmt.Sprintf("%s", delay)).Info("done waiting before triggering exit")
+	}
 	exitTriggered = true
 	InterruptMainContext()
 }

--- a/services/supervisor/health.go
+++ b/services/supervisor/health.go
@@ -82,7 +82,7 @@ func (sup *SupervisorService) ensureUp(knownContainer *Container, foundContainer
 		}
 		if !knownContainer.IsAgent && containerDetails.State.ExitCode == services.ExitCodeTriggered {
 			logger.Info("detected internal exit trigger - exiting")
-			services.TriggerExit()
+			services.TriggerExit(0)
 			return nil
 		}
 


### PR DESCRIPTION
Fixing two bugs that appeared today:
- Early context cancellation can cause missing bot requests: Internal exit trigger should be delayed at the source instead.
- In local mode, if there is a block range (i.e. a block number to stop at), old blocks should not be skipped. This is a mechanism to catch up in case the block source temporarily lags while scanning continuously, but it's a deal breaker in local mode.