### PR TITLE
Fix rare panic in bot log formatting

### DIFF
--- a/clients/docker.go
+++ b/clients/docker.go
@@ -717,6 +717,9 @@ func (d *dockerClient) GetContainerLogs(ctx context.Context, containerID, tail s
 			continue
 		}
 		prefixEnd := strings.Index(line, "2") // timestamp beginning
+		if prefixEnd < 0 || prefixEnd > len(line) {
+			continue
+		}
 		lines[i] = line[prefixEnd:]
 	}
 	return strings.Join(lines, "\n"), nil


### PR DESCRIPTION
From `675f79cc08e57ffadb875f8fa4cd3a6762885374` (v0.5.0):

```
panic: runtime error: slice bounds out of range [-1:]

goroutine 88 [running]:
github.com/forta-network/forta-node/clients.(*dockerClient).GetContainerLogs(0xc000032140, 0x13f2ca0, 0xc00078e240, 0xc011b7eb80, 0x40, 0x1156253, 0x2, 0x2710, 0xc01549d800, 0x1625, ...)
	/go/app/clients/docker.go:715 +0x3fa
github.com/forta-network/forta-node/services/supervisor.(*SupervisorService).doSyncAgentLogs(0xc0000d6a00, 0x0, 0x0)
	/go/app/services/supervisor/agent_logs.go:53 +0x37e
github.com/forta-network/forta-node/services/supervisor.(*SupervisorService).syncAgentLogs(0xc0000d6a00)
	/go/app/services/supervisor/agent_logs.go:24 +0xaa
created by github.com/forta-network/forta-node/services/supervisor.(*SupervisorService).start
	/go/app/services/supervisor/start.go:102 +0x1dc5
```