### PR TITLE
Run inspection at startup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -127,6 +127,7 @@ type LocalModeConfig struct {
 type InspectionConfig struct {
 	BlockInterval     *int `yaml:"blockInterval" json:"blockInterval"`
 	NetworkSavingMode bool `yaml:"networkSavingMode" json:"networkSavingMode"`
+	InspectAtStartup  bool `yaml:"inspectAtStartup" json:"inspect_at_startup" default:"true"`
 }
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -127,7 +127,7 @@ type LocalModeConfig struct {
 type InspectionConfig struct {
 	BlockInterval     *int `yaml:"blockInterval" json:"blockInterval"`
 	NetworkSavingMode bool `yaml:"networkSavingMode" json:"networkSavingMode"`
-	InspectAtStartup  bool `yaml:"inspectAtStartup" json:"inspect_at_startup" default:"true"`
+	InspectAtStartup  bool `yaml:"inspectAtStartup" json:"inspectAtStartup" default:"true"`
 }
 
 type Config struct {

--- a/services/inspector/inspector.go
+++ b/services/inspector/inspector.go
@@ -51,6 +51,11 @@ func (ins *Inspector) Start() error {
 		return nil
 	}
 
+	if ins.cfg.Config.InspectionConfig.InspectAtStartup {
+		blockNumber := ins.getClosestBlockToInspect()
+		ins.runInspection(blockNumber)
+	}
+
 	ins.registerMessageHandlers()
 
 	go func() {
@@ -60,22 +65,7 @@ func (ins *Inspector) Start() error {
 				return
 
 			case <-time.After(blockEventWaitTimeout):
-				// if scan api is failing, run a placeholder-like inspection with genesis block
-				dialCtx, cancel := context.WithTimeout(ins.ctx, time.Second*3)
-				rpcClient, err := rpc.DialContext(dialCtx, ins.cfg.Config.Scan.JsonRpc.Url)
-				cancel()
-				if err != nil {
-					ins.runInspection(0)
-					continue
-				}
-				reqCtx, cancel := context.WithTimeout(ins.ctx, time.Second*3)
-				blockNum, err := ethclient.NewClient(rpcClient).BlockNumber(reqCtx)
-				cancel()
-				if err != nil {
-					ins.runInspection(0)
-					continue
-				}
-				blockNum -= ins.blockNumRemainder(blockNum) // turn it into an expected block num
+				blockNum := ins.getClosestBlockToInspect()
 				ins.runInspection(blockNum)
 
 			case blockNum := <-ins.inspectCh:
@@ -104,19 +94,23 @@ func (ins *Inspector) runInspection(blockNum uint64) error {
 	ins.trackerMu.Lock()
 	ins.indicatorReports = nil
 	for indicatorName, indicatorValue := range results.Indicators {
-		ins.indicatorReports = append(ins.indicatorReports, &health.Report{
-			Name:    indicatorName,
-			Status:  health.StatusInfo,
-			Details: strconv.FormatFloat(indicatorValue, 'f', -1, 64),
-		})
+		ins.indicatorReports = append(
+			ins.indicatorReports, &health.Report{
+				Name:    indicatorName,
+				Status:  health.StatusInfo,
+				Details: strconv.FormatFloat(indicatorValue, 'f', -1, 64),
+			},
+		)
 	}
 	chainID := uint64(ins.cfg.Config.ChainID)
 	inspectionScore, _ := scorecalc.NewScoreCalculator([]scorecalc.ScoreCalculatorConfig{{ChainID: chainID}}).CalculateScore(chainID, results)
-	ins.indicatorReports = append(ins.indicatorReports, &health.Report{
-		Name:    "expected-score",
-		Status:  health.StatusInfo,
-		Details: strconv.FormatFloat(inspectionScore, 'f', -1, 64),
-	})
+	ins.indicatorReports = append(
+		ins.indicatorReports, &health.Report{
+			Name:    "expected-score",
+			Status:  health.StatusInfo,
+			Details: strconv.FormatFloat(inspectionScore, 'f', -1, 64),
+		},
+	)
 	ins.trackerMu.Unlock()
 
 	b, _ := json.Marshal(results)
@@ -189,6 +183,27 @@ func (ins *Inspector) Health() health.Reports {
 	ins.trackerMu.RUnlock()
 
 	return reports
+}
+
+func (ins *Inspector) getClosestBlockToInspect() uint64 {
+	// if scan api is failing, run a placeholder-like inspection with genesis block
+	dialCtx, cancel := context.WithTimeout(ins.ctx, time.Second*3)
+	rpcClient, err := rpc.DialContext(dialCtx, ins.cfg.Config.Scan.JsonRpc.Url)
+	cancel()
+	if err != nil {
+		return 0
+	}
+
+	reqCtx, cancel := context.WithTimeout(ins.ctx, time.Second*3)
+	blockNum, err := ethclient.NewClient(rpcClient).BlockNumber(reqCtx)
+	cancel()
+	if err != nil {
+		return 0
+	}
+
+	blockNum -= ins.blockNumRemainder(blockNum) // turn it into an expected block num
+
+	return blockNum
 }
 
 func NewInspector(ctx context.Context, cfg InspectorConfig) (*Inspector, error) {

--- a/services/supervisor/start.go
+++ b/services/supervisor/start.go
@@ -223,6 +223,12 @@ func (sup *SupervisorService) start() error {
 	}
 	sup.addContainerUnsafe(sup.inspectorContainer)
 
+	if sup.config.Config.InspectionConfig.InspectAtStartup {
+		if err := sup.client.WaitContainerStart(sup.ctx, sup.inspectorContainer.ID); err != nil {
+			return fmt.Errorf("failed while waiting for nats to start: %v", err)
+		}
+	}
+
 	sup.jsonRpcContainer, err = sup.client.StartContainer(
 		sup.ctx, clients.DockerContainerConfig{
 			Name:  config.DockerJSONRPCProxyContainerName,

--- a/services/supervisor/start.go
+++ b/services/supervisor/start.go
@@ -228,6 +228,10 @@ func (sup *SupervisorService) start() error {
 		if err := sup.client.WaitContainerStart(sup.ctx, sup.inspectorContainer.ID); err != nil {
 			return fmt.Errorf("failed while waiting for nats to start: %v", err)
 		}
+		
+		// this makes sure that inspector published a message. Which means publisher has also received it and
+		// inspection results will be available for every batch starting first batch.
+		<-sup.inspectionCh
 	}
 
 	sup.jsonRpcContainer, err = sup.client.StartContainer(

--- a/services/supervisor/start_agent.go
+++ b/services/supervisor/start_agent.go
@@ -198,6 +198,9 @@ func (sup *SupervisorService) handleAgentStop(payload messaging.AgentPayload) er
 func (sup *SupervisorService) registerMessageHandlers() {
 	sup.msgClient.Subscribe(messaging.SubjectAgentsActionRun, messaging.AgentsHandler(sup.handleAgentRun))
 	sup.msgClient.Subscribe(messaging.SubjectAgentsActionStop, messaging.AgentsHandler(sup.handleAgentStop))
+	if sup.config.Config.InspectionConfig.InspectAtStartup {
+		sup.msgClient.Subscribe(messaging.SubjectInspectionDone, messaging.InspectionResultsHandler(sup.handleInspectionResults))
+	}
 }
 
 func agentLogger(agent config.AgentConfig) *log.Entry {


### PR DESCRIPTION
@stevenlanders this runs an inspection at startup, blocks scanner deployment until the inspection is done