### PR TITLE
Decrease trace_block timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/ethereum/go-ethereum v1.10.16
 	github.com/fatih/color v1.13.0
-	github.com/forta-network/forta-core-go v0.0.0-20220915045733-764974422e0a
+	github.com/forta-network/forta-core-go v0.0.0-20220921163655-81db78f572b0
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/goccy/go-json v0.9.4
 	github.com/golang-jwt/jwt/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20220915045733-764974422e0a h1:gwUY/hXJ+IXoEM1eOIBkK847xhGXmtbkwsyJmaYAkFg=
-github.com/forta-network/forta-core-go v0.0.0-20220915045733-764974422e0a/go.mod h1:EqD2jws4EyOh/jRbXHfSFHCt3dYzjnLmxxd9sUXn09A=
+github.com/forta-network/forta-core-go v0.0.0-20220921163655-81db78f572b0 h1:xb3bi3XgLA7h/3n/tQXEFw8kerx5iM7PNJYuIN/ZGWM=
+github.com/forta-network/forta-core-go v0.0.0-20220921163655-81db78f572b0/go.mod h1:EqD2jws4EyOh/jRbXHfSFHCt3dYzjnLmxxd9sUXn09A=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
This upgrades `forta-core-go` which includes decreasing the trace_block timeout to 1 minute.