### PR TITLE
Use the safe offset in block feed when required

### DIFF
--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -33,6 +33,7 @@ import (
 
 func initTxStream(ctx context.Context, ethClient, traceClient ethereum.Client, cfg config.Config) (*scanner.TxStreamService, feeds.BlockFeed, error) {
 	cfg.Scan.JsonRpc.Url = utils.ConvertToDockerHostURL(cfg.Scan.JsonRpc.Url)
+	cfg.JsonRpcProxy.JsonRpc.Url = utils.ConvertToDockerHostURL(cfg.Scan.JsonRpc.Url)
 	cfg.Registry.JsonRpc.Url = utils.ConvertToDockerHostURL(cfg.Registry.JsonRpc.Url)
 	cfg.Registry.IPFS.APIURL = utils.ConvertToDockerHostURL(cfg.Registry.IPFS.APIURL)
 	cfg.Registry.IPFS.GatewayURL = utils.ConvertToDockerHostURL(cfg.Registry.IPFS.GatewayURL)

--- a/config/config.go
+++ b/config/config.go
@@ -146,6 +146,10 @@ type CombinerConfig struct {
 	CombinerCachePath string `yaml:"alertCachePath" json:"alert_cache_path"`
 }
 
+type AdvancedConfig struct {
+	SafeOffset bool `yaml:"safeOffset" json:"safeOffset"`
+}
+
 type Config struct {
 	// runtime values
 
@@ -174,6 +178,7 @@ type Config struct {
 	InspectionConfig InspectionConfig   `yaml:"inspection" json:"inspection"`
 	StorageConfig    StorageConfig      `yaml:"storage" json:"storage"`
 	CombinerConfig   CombinerConfig     `yaml:"combiner" json:"combiner"`
+	AdvancedConfig   AdvancedConfig     `yaml:"advanced" json:"advanced"`
 }
 
 func (cfg *Config) ConfigFilePath() string {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/ethereum/go-ethereum v1.10.16
 	github.com/fatih/color v1.13.0
-	github.com/forta-network/forta-core-go v0.0.0-20221116111105-9e0a836569c2
+	github.com/forta-network/forta-core-go v0.0.0-20221117094816-81e1501cf195
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/goccy/go-json v0.9.4
 	github.com/golang-jwt/jwt/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20221116111105-9e0a836569c2 h1:KZzgR+JrGYiNz5RbHtc1nm1407rDUxsWIQeZXfhQqZA=
-github.com/forta-network/forta-core-go v0.0.0-20221116111105-9e0a836569c2/go.mod h1:iSBw53DuxlRdyVLttbtSCIdbX1wF4zZGyFvczDznasM=
+github.com/forta-network/forta-core-go v0.0.0-20221117094816-81e1501cf195 h1:Sdr025DF+7uQCpdxYjsuEGkg8xnE3gCGaWMIH5AaTHQ=
+github.com/forta-network/forta-core-go v0.0.0-20221117094816-81e1501cf195/go.mod h1:iSBw53DuxlRdyVLttbtSCIdbX1wF4zZGyFvczDznasM=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=


### PR DESCRIPTION
Using new "safe offset"s in block feeds whenever
- Proxy API URL is set and it is different than scan API URL
- `advanced.safeOffset` is true in `config.yml` (force-enabling)

This allows stability in scanning with multiple providers in exchange of a minor drop in SLA score.