### PR TITLE
Use new Ethereum default offset 1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/ethereum/go-ethereum v1.10.16
 	github.com/fatih/color v1.13.0
-	github.com/forta-network/forta-core-go v0.0.0-20221223125452-ce18811bee16
+	github.com/forta-network/forta-core-go v0.0.0-20221227113544-6a849f5ecf05
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/goccy/go-json v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20221223125452-ce18811bee16 h1:6qAdx7lXitIwDwVkP67aA52siwhowv4nEpx2QHhiQgg=
-github.com/forta-network/forta-core-go v0.0.0-20221223125452-ce18811bee16/go.mod h1:Y3IAj2lFXQAKmmH6B4fAiUsCSDO19sr2U7/kdQw2+Aw=
+github.com/forta-network/forta-core-go v0.0.0-20221227113544-6a849f5ecf05 h1:YqnWocE5ImimBZmq17nZvS91w0syW2WQc8CouMfdjdQ=
+github.com/forta-network/forta-core-go v0.0.0-20221227113544-6a849f5ecf05/go.mod h1:Y3IAj2lFXQAKmmH6B4fAiUsCSDO19sr2U7/kdQw2+Aw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=


### PR DESCRIPTION
Helps avoid excessive `trace_block` retries (50%)