### PR TITLE
Avoid forta-scanner container crashes during assignment checks

### DIFF
--- a/cmd/inspector/main.go
+++ b/cmd/inspector/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/forta-network/forta-core-go/inspect"
 	"github.com/forta-network/forta-core-go/inspect/scorecalc"
 	"github.com/forta-network/forta-core-go/protocol/settings"
+	"github.com/forta-network/forta-core-go/security"
 	"github.com/forta-network/forta-node/config"
 	"github.com/forta-network/forta-node/healthutils"
 	"github.com/forta-network/forta-node/services"
@@ -20,10 +21,16 @@ var nodeConfig config.Config
 func initServices(ctx context.Context, cfg config.Config) ([]services.Service, error) {
 	nodeConfig = cfg
 
+	key, err := security.LoadKey(config.DefaultContainerKeyDirPath)
+	if err != nil {
+		return nil, err
+	}
+
 	inspector, err := inspector.NewInspector(ctx, inspector.InspectorConfig{
-		Config:    cfg,
-		ProxyHost: config.DockerJSONRPCProxyContainerName,
-		ProxyPort: config.DefaultJSONRPCProxyPort,
+		Config:         cfg,
+		ProxyHost:      config.DockerJSONRPCProxyContainerName,
+		ProxyPort:      config.DefaultJSONRPCProxyPort,
+		ScannerAddress: key.Address.String(),
 	})
 	if err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,7 @@ type LogConfig struct {
 
 type RegistryConfig struct {
 	ChainID              uint64        `yaml:"chainId" json:"chainId" default:"137"`
-	JsonRpc              JsonRpcConfig `yaml:"jsonRpc" json:"jsonRpc" default:"{\"url\": \"https://polygon-rpc.com\"}"`
+	JsonRpc              JsonRpcConfig `yaml:"jsonRpc" json:"jsonRpc" default:"{\"url\": \"https://rpc.ankr.com/polygon\"}"`
 	IPFS                 IPFSConfig    `yaml:"ipfs" json:"ipfs"`
 	ContainerRegistry    string        `yaml:"containerRegistry" json:"containerRegistry" validate:"hostname|hostname_port" default:"disco.forta.network" `
 	Username             string        `yaml:"username" json:"username"`
@@ -84,10 +84,9 @@ type ResourcesConfig struct {
 }
 
 type ENSConfig struct {
-	DefaultContract bool          `yaml:"defaultContract" json:"defaultContract" default:"false" `
-	ContractAddress string        `yaml:"contractAddress" json:"contractAddress" validate:"omitempty,eth_addr" default:"0x08f42fcc52a9C2F391bF507C4E8688D0b53e1bd7"`
-	JsonRpc         JsonRpcConfig `yaml:"jsonRpc" json:"jsonRpc" default:"{\"url\": \"https://polygon-rpc.com\"}" `
-	Override        bool          `yaml:"override" json:"override" default:"false"`
+	DefaultContract bool   `yaml:"defaultContract" json:"defaultContract" default:"false" `
+	ContractAddress string `yaml:"contractAddress" json:"contractAddress" validate:"omitempty,eth_addr" default:"0x08f42fcc52a9C2F391bF507C4E8688D0b53e1bd7"`
+	Override        bool   `yaml:"override" json:"override" default:"false"`
 }
 
 type TelemetryConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230202212454-88da8178256b
+	github.com/forta-network/forta-core-go v0.0.0-20230206231612-c1aedd9e8a26
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230206231612-c1aedd9e8a26
+	github.com/forta-network/forta-core-go v0.0.0-20230207164254-182e928d47ed
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230207164254-182e928d47ed
+	github.com/forta-network/forta-core-go v0.0.0-20230207180329-3425d3c96e89
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230206231612-c1aedd9e8a26 h1:cwiITnDFa6B2i4X3THnT9dGFhAwB1Q/Y6viDYIvKzsY=
-github.com/forta-network/forta-core-go v0.0.0-20230206231612-c1aedd9e8a26/go.mod h1:c3acQH/1rEQjquAb6ebPYH5dNRuOnYv0QdoNIwGlmtA=
+github.com/forta-network/forta-core-go v0.0.0-20230207164254-182e928d47ed h1:RowDFtiiNGGYemtgMrXsjqEpuT5qb5pE4MHKDLmKeIY=
+github.com/forta-network/forta-core-go v0.0.0-20230207164254-182e928d47ed/go.mod h1:c3acQH/1rEQjquAb6ebPYH5dNRuOnYv0QdoNIwGlmtA=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230207164254-182e928d47ed h1:RowDFtiiNGGYemtgMrXsjqEpuT5qb5pE4MHKDLmKeIY=
-github.com/forta-network/forta-core-go v0.0.0-20230207164254-182e928d47ed/go.mod h1:c3acQH/1rEQjquAb6ebPYH5dNRuOnYv0QdoNIwGlmtA=
+github.com/forta-network/forta-core-go v0.0.0-20230207180329-3425d3c96e89 h1:a/NH8SY32/S2b0Gawgglt1hEiK8w1wZcJwGkFX2mSug=
+github.com/forta-network/forta-core-go v0.0.0-20230207180329-3425d3c96e89/go.mod h1:c3acQH/1rEQjquAb6ebPYH5dNRuOnYv0QdoNIwGlmtA=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230202212454-88da8178256b h1:u0vmvH7ivEGKZg/eh6XNDpTnjFKjwplxbBDQ/pOiOKc=
-github.com/forta-network/forta-core-go v0.0.0-20230202212454-88da8178256b/go.mod h1:c3acQH/1rEQjquAb6ebPYH5dNRuOnYv0QdoNIwGlmtA=
+github.com/forta-network/forta-core-go v0.0.0-20230206231612-c1aedd9e8a26 h1:cwiITnDFa6B2i4X3THnT9dGFhAwB1Q/Y6viDYIvKzsY=
+github.com/forta-network/forta-core-go v0.0.0-20230206231612-c1aedd9e8a26/go.mod h1:c3acQH/1rEQjquAb6ebPYH5dNRuOnYv0QdoNIwGlmtA=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/services/supervisor/start.go
+++ b/services/supervisor/start.go
@@ -311,6 +311,9 @@ ipfs config Datastore.StorageMax '1GB'
 			Ports: map[string]string{
 				"": config.DefaultHealthPort, // random host port
 			},
+			Files: map[string][]byte{
+				"passphrase": []byte(sup.config.Passphrase),
+			},
 			DialHost:       true,
 			NetworkID:      nodeNetworkID,
 			LinkNetworkIDs: []string{natsNetworkID},


### PR DESCRIPTION
- Use the new registry inspection so the nodes, which cannot read from the registry well, have a low score
- Avoid panic in reading the assignment hash
- Use Ankr Polygon as the default JSON-RPC API for the registry