### PR TITLE
remove enabled check from registry store

### DIFF
--- a/store/registry.go
+++ b/store/registry.go
@@ -57,15 +57,6 @@ func (rs *registryStore) GetAgentsIfChanged(scanner string) ([]*config.AgentConf
 		return nil, false, err
 	}
 
-	// if the scan node is disabled, it must run no agents
-	isEnabledScanner, err := rs.rc.IsEnabledScanner(scanner)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to check if scanner is enabled: %v", err)
-	}
-	if !isEnabledScanner {
-		return []*config.AgentConfig{}, true, nil
-	}
-
 	shouldUpdate := rs.lastCompletedVersion != hash.Hash || time.Since(rs.lastUpdate) > 1*time.Hour
 	if !shouldUpdate {
 		return nil, false, nil


### PR DESCRIPTION
Alert API authorization mechanism already has protection against unregistered or disabled nodes. In other sense, batches or alerts from disabled nodes will not be accepted, so checking for the scanner's `enabled` status on scan nodes only prevents them from running bots when they are disabled but doesn't add any more security coverage.

IMHO, to mitigate any risks coming with an arbitrary redundant contract interaction, we should disable this check and let the disabled nodes do whatever they want. Besides, in an ideal world dispatch contract should return 0 assigned bots for disabled nodes anyways.