### PR TITLE
Improve combiner dispatch authorization

### DIFF
--- a/clients/messaging/client.go
+++ b/clients/messaging/client.go
@@ -139,7 +139,7 @@ func (client *Client) PublishProto(subject string, payload proto.Message) {
 	if err := client.nc.Publish(subject, data); err != nil {
 		logger.Errorf("failed to publish msg: %v", err)
 	}
-	logger.Debugf("published: %s", string(data))
+	logger.Tracef("published: %s", string(data))
 }
 
 type nopClient struct{}

--- a/clients/messaging/subjects.go
+++ b/clients/messaging/subjects.go
@@ -1,7 +1,7 @@
 package messaging
 
 import (
-	"github.com/forta-network/forta-core-go/feeds"
+	"github.com/forta-network/forta-core-go/domain"
 	"github.com/forta-network/forta-core-go/protocol"
 	"github.com/forta-network/forta-node/config"
 )
@@ -31,7 +31,7 @@ type AgentMetricPayload *protocol.AgentMetricList
 
 
 // SubscriptionPayload is the message payload for combiner bot subscriptions.
-type SubscriptionPayload []*feeds.CombinerBotSubscription
+type SubscriptionPayload []*domain.CombinerBotSubscription
 
 // ScannerPayload is the message payload for general scanner info.
 type ScannerPayload struct {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230411194301-375eb318bcf4
+	github.com/forta-network/forta-core-go v0.0.0-20230412075000-0313dd3b5267
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230411080807-e6a39c0c9b49
+	github.com/forta-network/forta-core-go v0.0.0-20230411134546-03178f656a1c
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230411134546-03178f656a1c
+	github.com/forta-network/forta-core-go v0.0.0-20230411194301-375eb318bcf4
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230412075000-0313dd3b5267
+	github.com/forta-network/forta-core-go v0.0.0-20230424123205-ea9d15a9e273
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230412075000-0313dd3b5267 h1:m//u4XQryJMP2YZJRTLm33cUkBHbT3EN0rh8ESbSXmU=
-github.com/forta-network/forta-core-go v0.0.0-20230412075000-0313dd3b5267/go.mod h1:gffFqv24ErxEILzjvhXCaVHa2dljzdILlaJyUlkDnfw=
+github.com/forta-network/forta-core-go v0.0.0-20230424123205-ea9d15a9e273 h1:TrMqWwRH/85/1dWqWnSd89u4OZSzL2ubgdOaVokT0qo=
+github.com/forta-network/forta-core-go v0.0.0-20230424123205-ea9d15a9e273/go.mod h1:gffFqv24ErxEILzjvhXCaVHa2dljzdILlaJyUlkDnfw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230411080807-e6a39c0c9b49 h1:tuA1pXnAPhY5lGRxQgdVGwZEI/6avsi3OfQ59IVjMsU=
-github.com/forta-network/forta-core-go v0.0.0-20230411080807-e6a39c0c9b49/go.mod h1:gffFqv24ErxEILzjvhXCaVHa2dljzdILlaJyUlkDnfw=
+github.com/forta-network/forta-core-go v0.0.0-20230411134546-03178f656a1c h1:qrEXJvp2MqFe5dOU4K75e45w2NT+OXlHUUCkiJatwfo=
+github.com/forta-network/forta-core-go v0.0.0-20230411134546-03178f656a1c/go.mod h1:gffFqv24ErxEILzjvhXCaVHa2dljzdILlaJyUlkDnfw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230411134546-03178f656a1c h1:qrEXJvp2MqFe5dOU4K75e45w2NT+OXlHUUCkiJatwfo=
-github.com/forta-network/forta-core-go v0.0.0-20230411134546-03178f656a1c/go.mod h1:gffFqv24ErxEILzjvhXCaVHa2dljzdILlaJyUlkDnfw=
+github.com/forta-network/forta-core-go v0.0.0-20230411194301-375eb318bcf4 h1:khH3F2MgnOV+hKF5QcXn2OHBzIsMOKGO4qdq3xUTtUs=
+github.com/forta-network/forta-core-go v0.0.0-20230411194301-375eb318bcf4/go.mod h1:gffFqv24ErxEILzjvhXCaVHa2dljzdILlaJyUlkDnfw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230411194301-375eb318bcf4 h1:khH3F2MgnOV+hKF5QcXn2OHBzIsMOKGO4qdq3xUTtUs=
-github.com/forta-network/forta-core-go v0.0.0-20230411194301-375eb318bcf4/go.mod h1:gffFqv24ErxEILzjvhXCaVHa2dljzdILlaJyUlkDnfw=
+github.com/forta-network/forta-core-go v0.0.0-20230412075000-0313dd3b5267 h1:m//u4XQryJMP2YZJRTLm33cUkBHbT3EN0rh8ESbSXmU=
+github.com/forta-network/forta-core-go v0.0.0-20230412075000-0313dd3b5267/go.mod h1:gffFqv24ErxEILzjvhXCaVHa2dljzdILlaJyUlkDnfw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/services/scanner/agentpool/agent_pool.go
+++ b/services/scanner/agentpool/agent_pool.go
@@ -296,6 +296,7 @@ func (ap *AgentPool) SendEvaluateAlertRequest(req *protocol.EvaluateAlertRequest
 			continue
 		}
 		target = agent
+		break
 	}
 
 	// return if can't find the target bot, or it's not ready yet

--- a/services/scanner/agentpool/agent_pool_test.go
+++ b/services/scanner/agentpool/agent_pool_test.go
@@ -112,12 +112,14 @@ func (s *Suite) TestStartProcessStop() {
 	blockReq := &protocol.EvaluateBlockRequest{Event: &protocol.BlockEvent{BlockNumber: "123123"}}
 	blockResp := &protocol.EvaluateBlockResponse{Metadata: map[string]string{"imageHash": ""}}
 	combinerReq := &protocol.EvaluateAlertRequest{
+		TargetBotId: testAgentID,
 		Event: &protocol.AlertEvent{
 			Alert: &protocol.AlertEvent_Alert{
-				Hash:   "123123",
-				Source: &protocol.AlertEvent_Alert_Source{Bot: &protocol.AlertEvent_Alert_Bot{Id: testCombinerSourceBot}},
+				Hash:      "123123",
+				Source:    &protocol.AlertEvent_Alert_Source{Bot: &protocol.AlertEvent_Alert_Bot{Id: testCombinerSourceBot}},
 				CreatedAt: time.Now().Format(time.RFC3339Nano),
 			},
+
 		},
 	}
 	// save combiner subscription

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -89,7 +89,7 @@ func (agent *Agent) CombinerBotSubscriptions() []domain.CombinerBotSubscription 
 	defer agent.mu.RUnlock()
 
 	var subscriptions []domain.CombinerBotSubscription
-	if agent.IsCombinerBot() {
+	if !agent.IsCombinerBot() {
 		return subscriptions
 	}
 	

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -632,42 +632,28 @@ func (agent *Agent) ShouldProcessAlert(event *protocol.AlertEvent) bool {
 		return false
 	}
 
-	for _, subscription := range agent.config.AlertConfig.Subscriptions {
-		// bot is subscribed to the bot id
-		subscribedToBot := subscription.BotId == "" || subscription.BotId == event.Alert.Source.Bot.Id
-		// bot is subscribed to the alert id
-		subscribedToAlert := subscription.AlertId == "" || subscription.AlertId == event.Alert.AlertId
-		// correct chain id
-		correctChainID := subscription.ChainId == 0 || subscription.ChainId == event.Alert.ChainId
+	// handle sharding
+	alertCreatedAt, err := time.Parse(time.RFC3339Nano, event.Alert.CreatedAt)
+	if err != nil {
+		log.WithFields(
+			log.Fields{
+				"alertHash": event.Alert.Hash,
+				"createdAt": event.Alert.CreatedAt,
+				"botId":     agent.config.ID,
+			},
+		).Warn("failed to parse created at for sharding calculation")
 
-		// handle sharding
-		alertCreatedAt, err := time.Parse(time.RFC3339Nano, event.Alert.CreatedAt)
-		if err != nil {
-			log.WithFields(
-				log.Fields{
-					"alertHash": event.Alert.Hash,
-					"createdAt": event.Alert.CreatedAt,
-					"botId":     agent.config.ID,
-				},
-			).Warn("failed to parse created at for sharding calculation")
-
-			return false
-		}
-
-		var isOnThisShard bool
-		if agent.IsSharded() {
-			isOnThisShard = uint(alertCreatedAt.Unix())%agent.config.ShardConfig.Shards == agent.config.ShardConfig.ShardID
-		} else {
-			isOnThisShard = true
-		}
-
-		// if matches at least one subscription of the bot
-		if subscribedToBot && subscribedToAlert && correctChainID && isOnThisShard {
-			return true
-		}
+		return false
 	}
 
-	return false
+	var isOnThisShard bool
+	if agent.IsSharded() {
+		isOnThisShard = uint(alertCreatedAt.Unix())%agent.config.ShardConfig.Shards == agent.config.ShardConfig.ShardID
+	} else {
+		isOnThisShard = true
+	}
+
+	return isOnThisShard
 }
 
 func (agent *Agent) SetShardConfig(cfg config.AgentConfig) {

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -84,6 +84,28 @@ func (agent *Agent) IsCombinerBot() bool {
 
 	return len(agent.config.AlertConfig.Subscriptions) > 0
 }
+func (agent *Agent) CombinerBotSubscriptions() []domain.CombinerBotSubscription {
+	agent.mu.RLock()
+	defer agent.mu.RUnlock()
+
+	var subscriptions []domain.CombinerBotSubscription
+	if agent.IsCombinerBot() {
+		return subscriptions
+	}
+	
+	for _, subscription := range agent.AlertConfig().Subscriptions {
+		subscriptions = append(
+			subscriptions, domain.CombinerBotSubscription{
+				Subscription: subscription,
+				Subscriber: &domain.Subscriber{
+					BotID:    agent.Config().ID,
+					BotOwner: agent.Config().Owner,
+				},
+			},
+		)
+	}
+	return subscriptions
+}
 
 // TxRequest contains the original request data and the encoded message.
 type TxRequest struct {

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -353,6 +353,7 @@ func (agent *Agent) processTransaction(lg *log.Entry, request *TxRequest) (exit 
 
 		return false
 	}
+
 	lg.WithField("duration", time.Since(startTime)).WithError(err).Error("error invoking agent")
 	if agent.errCounter.TooManyErrs(err) {
 		lg.WithField("duration", time.Since(startTime)).Error("too many errors - shutting down agent")
@@ -483,7 +484,7 @@ func (agent *Agent) processCombinationAlert(lg *log.Entry, request *CombinationR
 
 	startTime := time.Now()
 	if agent.IsClosed() {
-		agent.mu.RUnlock()
+		return true
 	}
 
 	ctx, cancel := context.WithTimeout(agent.ctx, AgentTimeout)

--- a/services/scanner/combiner_analyzer.go
+++ b/services/scanner/combiner_analyzer.go
@@ -154,7 +154,7 @@ func (aas *CombinerAlertAnalyzerService) Start() error {
 
 			// create a request
 			requestId := uuid.Must(uuid.NewUUID())
-			request := &protocol.EvaluateAlertRequest{RequestId: requestId.String(), Event: alertEvt}
+			request := &protocol.EvaluateAlertRequest{RequestId: requestId.String(), Event: alertEvt, TargetBotId: alert.Subscriber.BotID}
 
 			// forward to the pool
 			aas.cfg.AgentPool.SendEvaluateAlertRequest(request)

--- a/services/scanner/combiner_analyzer.go
+++ b/services/scanner/combiner_analyzer.go
@@ -144,17 +144,27 @@ func (aas *CombinerAlertAnalyzerService) Start() error {
 	// Gear 1: loops over alerts and distributes to all agents
 	go func() {
 		// for each alert
-		for alert := range aas.cfg.AlertChannel {
+		for alertEvt := range aas.cfg.AlertChannel {
+			logger := log.WithFields(
+				log.Fields{
+					"component": "combinerAnalyzer",
+					"target":    alertEvt.Subscriber.BotID,
+					"source":    alertEvt.Event.Alert.Source.Bot.Id,
+				},
+			)
+
+			logger.Debug("received alert")
+
 			// convert to message
-			alertEvt, err := alert.ToMessage()
+			alertEvtMsg, err := alertEvt.ToMessage()
 			if err != nil {
-				log.WithError(err).Error("error converting alert event to message (skipping)")
+				logger.WithError(err).Error("error converting alert event to message (skipping)")
 				continue
 			}
 
 			// create a request
 			requestId := uuid.Must(uuid.NewUUID())
-			request := &protocol.EvaluateAlertRequest{RequestId: requestId.String(), Event: alertEvt, TargetBotId: alert.Subscriber.BotID}
+			request := &protocol.EvaluateAlertRequest{RequestId: requestId.String(), Event: alertEvtMsg, TargetBotId: alertEvt.Subscriber.BotID}
 
 			// forward to the pool
 			aas.cfg.AgentPool.SendEvaluateAlertRequest(request)

--- a/services/scanner/combiner_stream.go
+++ b/services/scanner/combiner_stream.go
@@ -47,10 +47,12 @@ func (t *CombinerAlertStreamService) handleAlert(evt *domain.AlertEvent) error {
 
 	log.WithFields(
 		log.Fields{
-			"subscribee": evt.Event.Alert.Source.Bot.Id,
-			"alert":      evt.Event.Alert.Hash,
+			"subscribee":  evt.Event.Alert.Source.Bot.Id,
+			"alert":       evt.Event.Alert.Hash,
+			"sourceBot":   evt.Subscriber.BotID,
+			"sourceOwner": evt.Subscriber.BotOwner,
 		},
-	).Debug("streaming new alert subscription")
+	).Debug("streaming new alert event")
 
 	t.alertOutput <- evt
 	t.lastAlertActivity.Set()

--- a/store/registry.go
+++ b/store/registry.go
@@ -368,6 +368,7 @@ func (rs *privateRegistryStore) GetAgentsIfChanged(scanner string) ([]*config.Ag
 			continue
 		}
 
+		agtCfg.Owner = agt.Owner
 		agentConfigs = append(agentConfigs, agtCfg)
 	}
 

--- a/tests/e2e/e2e_forta_local_mode_test.go
+++ b/tests/e2e/e2e_forta_local_mode_test.go
@@ -86,7 +86,10 @@ localMode:
   includeMetrics: true
   webhookUrl: %s
   logFileName: %s
-  botImages:
+# following will deploy 2 different bots with same image, but the first one will be treated
+# as if it has a valid data fee subscription
+  botImages:  
+    - forta-e2e-alert-test-agent
     - forta-e2e-alert-test-agent
   runtimeLimits:
     stopTimeoutSeconds: 30
@@ -249,6 +252,11 @@ func (s *Suite) runLocalModeAlertHandler(webhookURL, logFileName string, readAle
 	var (
 		combinationAlert *models.Alert
 	)
+
+	// only the bot with data fee subscription should submit alert, other bot shouldn't be fed any alerts
+	for _, alert := range webhookAlerts.Alerts {
+		s.r.Equal(alert.Source.Bot.ID, botWithDataFeeSubscription)
+	}
 
 	for _, alert := range webhookAlerts.Alerts {
 		if alert.AlertID == combinerbotalertid.CombinationAlertID {

--- a/testutils/graphql-api/main.go
+++ b/testutils/graphql-api/main.go
@@ -79,6 +79,10 @@ func (q *GraphQLAPI) Close() error {
 }
 
 func New(ctx context.Context, port int) *GraphQLAPI {
+	return NewWithAuthMiddleware(ctx, port, authMiddleware)
+}
+
+func NewWithAuthMiddleware(ctx context.Context, port int, authorizer func(handlerFunc http.HandlerFunc) http.HandlerFunc) *GraphQLAPI {
 	api := &GraphQLAPI{
 		port: port,
 	}
@@ -86,7 +90,7 @@ func New(ctx context.Context, port int) *GraphQLAPI {
 	api.ctx, api.cancel = context.WithCancel(ctx)
 
 	r := mux.NewRouter()
-	r.HandleFunc("/graphql", authMiddleware(dataHandler)).Methods("POST")
+	r.HandleFunc("/graphql", authorizer(dataHandler)).Methods("POST")
 	api.router = r
 
 	return api


### PR DESCRIPTION
e2e test improvement:
handle alert test now deploys 2 bots with same image, one treated as "having a data fee subscription", and the other does not.

dispatch changes:
handle alert events now has the subscriber(target) information to prevent unauthorized bots from accessing alert data