### PR TITLE
submit metrics on bot restarts

### DIFF
--- a/metrics/agent_metrics.go
+++ b/metrics/agent_metrics.go
@@ -42,6 +42,7 @@ const (
 	MetricCombinerError           = "combiner.error"
 	MetricCombinerSuccess         = "combiner.success"
 	MetricCombinerDrop            = "combiner.drop"
+	MetricBotStarted              = "agent.start"
 )
 
 func SendAgentMetrics(client clients.MessageClient, ms []*protocol.AgentMetric) {

--- a/metrics/agent_metrics.go
+++ b/metrics/agent_metrics.go
@@ -28,6 +28,7 @@ const (
 	MetricBlockSuccess            = "block.success"
 	MetricBlockDrop               = "block.drop"
 	MetricStop                    = "agent.stop"
+	MetricStart                   = "agent.start"
 	MetricJSONRPCLatency          = "jsonrpc.latency"
 	MetricJSONRPCRequest          = "jsonrpc.request"
 	MetricJSONRPCSuccess          = "jsonrpc.success"
@@ -42,7 +43,6 @@ const (
 	MetricCombinerError           = "combiner.error"
 	MetricCombinerSuccess         = "combiner.success"
 	MetricCombinerDrop            = "combiner.drop"
-	MetricBotStarted              = "agent.start"
 )
 
 func SendAgentMetrics(client clients.MessageClient, ms []*protocol.AgentMetric) {

--- a/services/scanner/agentpool/agent_pool_test.go
+++ b/services/scanner/agentpool/agent_pool_test.go
@@ -78,6 +78,8 @@ func (s *Suite) TestStartProcessStop() {
 	}
 	emptyPayload := messaging.AgentPayload{}
 
+	// Prior to invoking initialize method, agent.start metric should be emitted.
+	s.msgClient.EXPECT().PublishProto(messaging.SubjectMetricAgent,gomock.Any())
 	s.agentClient.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	// Given that there are no agents running

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -255,6 +255,10 @@ func (agent *Agent) StartProcessing() {
 func (agent *Agent) initialize() {
 	defer agent.initWait.Done()
 
+	logger := log.WithFields(log.Fields{
+			"agent": agent.config.ID,
+	})
+
 	// public bot.start metric to track bot starts/restarts.
 	agent.msgClient.PublishProto(
 		messaging.SubjectMetricAgent, &protocol.AgentMetricList{
@@ -269,20 +273,14 @@ func (agent *Agent) initialize() {
 		},
 	)
 
-	logger := log.WithFields(
-		log.Fields{
-			"agent": agent.config.ID,
-		},
-	)
-
 	ctx, cancel := context.WithTimeout(agent.ctx, DefaultAgentInitializeTimeout)
 	defer cancel()
 
 	// invoke initialize method of the bot
 	initializeResponse, err := agent.client.Initialize(ctx, &protocol.InitializeRequest{
-			AgentId:   agent.config.ID,
-			ProxyHost: config.DockerJSONRPCProxyContainerName,
-		})
+		AgentId:   agent.config.ID,
+		ProxyHost: config.DockerJSONRPCProxyContainerName,
+	})
 
 	// it is not mandatory to implement a initialize method, safe to skip
 	if status.Code(err) == codes.Unimplemented {

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -278,20 +278,17 @@ func (agent *Agent) initialize() {
 	ctx, cancel := context.WithTimeout(agent.ctx, DefaultAgentInitializeTimeout)
 	defer cancel()
 
-	// invoke initialize method of bot.
-	initializeResponse, err := agent.client.Initialize(
-		ctx, &protocol.InitializeRequest{
+	// invoke initialize method of the bot
+	initializeResponse, err := agent.client.Initialize(ctx, &protocol.InitializeRequest{
 			AgentId:   agent.config.ID,
 			ProxyHost: config.DockerJSONRPCProxyContainerName,
-		},
-	)
+		})
 
-	// it is not mandatory to implement a initialize method
+	// it is not mandatory to implement a initialize method, safe to skip
 	if status.Code(err) == codes.Unimplemented {
 		logger.WithError(err).Info("initialize() method not implemented in bot - safe to ignore")
 		return
 	}
-
 	if err != nil {
 		logger.WithError(err).Warn("bot initialization failed")
 		return
@@ -302,7 +299,7 @@ func (agent *Agent) initialize() {
 		return
 	}
 
-	// pass new alert subscriptions to pool
+	// pass new alert subscriptions to the agent pool
 	if initializeResponse != nil && initializeResponse.AlertConfig != nil {
 		agent.SetAlertConfig(initializeResponse.AlertConfig)
 	}

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -266,7 +266,7 @@ func (agent *Agent) initialize() {
 				{
 					AgentId:   agent.config.ID,
 					Timestamp: time.Now().Format(time.RFC3339),
-					Name:      metrics.MetricBotStarted,
+					Name:      metrics.MetricStart,
 					Value:     1,
 				},
 			},


### PR DESCRIPTION
A metric `agent.start` will be published whenever a bot is being initialized by the supervisor