### PR TITLE
Improve handle alert e2e tests

### DIFF
--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -158,6 +158,7 @@ func initCombinationStream(ctx context.Context, msgClient clients.MessageClient,
 			Start:             cfg.LocalModeConfig.RuntimeLimits.StartCombiner,
 			End:               cfg.LocalModeConfig.RuntimeLimits.StopCombiner,
 			CombinerCachePath: cfg.CombinerConfig.CombinerCachePath,
+			QueryInterval:     cfg.CombinerConfig.QueryInterval,
 		},
 	)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -194,6 +194,7 @@ type StorageConfig struct {
 type CombinerConfig struct {
 	AlertAPIURL       string `yaml:"alertApiUrl" json:"alertApiUrl" default:"http://forta-public-api:8535" validate:"url"`
 	CombinerCachePath string `yaml:"alertCachePath" json:"alertCachePath"`
+	QueryInterval     uint64 `yaml:"queryInterval" json:"queryInterval"`
 }
 
 type AdvancedConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230505105317-b015ab0cf8ba
+	github.com/forta-network/forta-core-go v0.0.0-20230505114527-2bd8f78afb84
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/forta-network/forta-core-go v0.0.0-20230425115851-07b6074badf1
+	github.com/forta-network/forta-core-go v0.0.0-20230505105317-b015ab0cf8ba
 	github.com/libp2p/go-libp2p v0.23.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/cors v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230505105317-b015ab0cf8ba h1:ykl4UHz19VP6DDi+J6KKbKI3dLVRIS0e3YZQM10Mujo=
-github.com/forta-network/forta-core-go v0.0.0-20230505105317-b015ab0cf8ba/go.mod h1:YOEItQKGLsl5Wf93P9YKq/D01OxV6aFY0aVVoscfhe8=
+github.com/forta-network/forta-core-go v0.0.0-20230505114527-2bd8f78afb84 h1:mqMO0m2izQlimwjPjubSVeJ5fB2nKjKfe1M3Wi5uhyo=
+github.com/forta-network/forta-core-go v0.0.0-20230505114527-2bd8f78afb84/go.mod h1:YOEItQKGLsl5Wf93P9YKq/D01OxV6aFY0aVVoscfhe8=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/forta-network/forta-core-go v0.0.0-20230425115851-07b6074badf1 h1:SiIDSqkCanVcROdU55zhBhv8edMuhAzpvLNCr1N/3qA=
-github.com/forta-network/forta-core-go v0.0.0-20230425115851-07b6074badf1/go.mod h1:YOEItQKGLsl5Wf93P9YKq/D01OxV6aFY0aVVoscfhe8=
+github.com/forta-network/forta-core-go v0.0.0-20230505105317-b015ab0cf8ba h1:ykl4UHz19VP6DDi+J6KKbKI3dLVRIS0e3YZQM10Mujo=
+github.com/forta-network/forta-core-go v0.0.0-20230505105317-b015ab0cf8ba/go.mod h1:YOEItQKGLsl5Wf93P9YKq/D01OxV6aFY0aVVoscfhe8=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=

--- a/services/public-api/public_api_proxy.go
+++ b/services/public-api/public_api_proxy.go
@@ -202,7 +202,7 @@ func (p *PublicAPIProxy) Stop() error {
 }
 
 func (p *PublicAPIProxy) Name() string {
-	return "json-rpc-proxy"
+	return "public-api-proxy"
 }
 
 func getBotFromContext(ctx context.Context) (string, string, bool, bool) {

--- a/tests/e2e/e2e_forta_local_mode_test.go
+++ b/tests/e2e/e2e_forta_local_mode_test.go
@@ -114,6 +114,8 @@ publicApiProxy:
 
 log:
   level: debug
+combiner:
+  queryInterval: 3000
 `
 
 const localModeDir = ".forta-local"

--- a/testutils/graphql-api/main.go
+++ b/testutils/graphql-api/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/forta-network/forta-core-go/utils/apiutils"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 )
 
 type Alert struct {
@@ -62,7 +63,7 @@ type GraphQLAPI struct {
 
 // Start starts the server.
 func (q *GraphQLAPI) Start() {
-	apiutils.ListenAndServe(
+	err := apiutils.ListenAndServe(
 		q.ctx, &http.Server{
 			Handler:      q.router,
 			Addr:         fmt.Sprintf("0.0.0.0:%d", q.port),
@@ -70,6 +71,9 @@ func (q *GraphQLAPI) Start() {
 			ReadTimeout:  15 * time.Second,
 		}, "started graphql api",
 	)
+	if err != nil {
+		log.WithError(err).Warn("mock graphql api exited with error")
+	}
 }
 
 // Close closes the server.


### PR DESCRIPTION
Default query interval for alert fetching in combiner feed is 1 minute and not configurable, making tests take too longs and even timeout in certain cases. This pr makes the interval configurable