### PR TITLE
Always publish latest bots

### DIFF
--- a/services/registry/registry.go
+++ b/services/registry/registry.go
@@ -116,21 +116,15 @@ func (rs *RegistryService) publishLatestAgents() error {
 			return fmt.Errorf("failed to get the scanner list agents version: %v", err)
 		}
 
-		if agts != nil {
-			rs.agentsConfigs = agts
-		}
-
 		if changed {
 			rs.lastChangeDetected.Set()
+			rs.agentsConfigs = agts
 			log.WithField("count", len(agts)).Infof("publishing list of agents")
 		} else {
 			log.Info("registry: no agent changes detected")
 		}
 
-		if rs.agentsConfigs != nil {
-			rs.msgClient.Publish(messaging.SubjectAgentsVersionsLatest, rs.agentsConfigs)
-		}
-
+		rs.msgClient.Publish(messaging.SubjectAgentsVersionsLatest, rs.agentsConfigs)
 	}
 	return nil
 }

--- a/services/registry/registry.go
+++ b/services/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"github.com/forta-network/forta-node/clients/messaging"
 	"time"
 
 	"github.com/forta-network/forta-node/store"
@@ -13,7 +14,6 @@ import (
 	"github.com/forta-network/forta-core-go/ethereum"
 	"github.com/forta-network/forta-core-go/feeds"
 	"github.com/forta-network/forta-node/clients"
-	"github.com/forta-network/forta-node/clients/messaging"
 	"github.com/forta-network/forta-node/config"
 	"github.com/forta-network/forta-node/services/registry/regtypes"
 	log "github.com/sirupsen/logrus"
@@ -116,14 +116,21 @@ func (rs *RegistryService) publishLatestAgents() error {
 			return fmt.Errorf("failed to get the scanner list agents version: %v", err)
 		}
 
+		if agts != nil {
+			rs.agentsConfigs = agts
+		}
+
 		if changed {
 			rs.lastChangeDetected.Set()
 			log.WithField("count", len(agts)).Infof("publishing list of agents")
-			rs.agentsConfigs = agts
-			rs.msgClient.Publish(messaging.SubjectAgentsVersionsLatest, agts)
 		} else {
 			log.Info("registry: no agent changes detected")
 		}
+
+		if rs.agentsConfigs != nil {
+			rs.msgClient.Publish(messaging.SubjectAgentsVersionsLatest, rs.agentsConfigs)
+		}
+
 	}
 	return nil
 }

--- a/services/registry/registry_test.go
+++ b/services/registry/registry_test.go
@@ -105,7 +105,21 @@ func (s *Suite) TestPublishChanges() {
 	s.NoError(s.service.publishLatestAgents())
 }
 
-func (s *Suite) TestDoNotPublishChanges() {
+func (s *Suite) TestDoNotPublishChangesIfNil() {
 	s.registryStore.EXPECT().GetAgentsIfChanged(s.service.scannerAddress.Hex()).Return(nil, false, nil)
+	s.NoError(s.service.publishLatestAgents())
+}
+
+func (s *Suite) TestPublishEvenIfNoChanges() {
+	configs := (agentConfigs)([]*config.AgentConfig{
+		{
+			ID:    testAgentIDStr,
+			Image: fmt.Sprintf("%s/%s", testContainerRegistry, testImageRef),
+		},
+	})
+
+	s.registryStore.EXPECT().GetAgentsIfChanged(s.service.scannerAddress.Hex()).Return(configs, false, nil)
+	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsVersionsLatest, configs)
+
 	s.NoError(s.service.publishLatestAgents())
 }


### PR DESCRIPTION
This publishes the bot list for every iteration of the registry service to be more tolerant to missed messages.