### PR TITLE
update bot manifest on version updates

### DIFF
--- a/services/scanner/agentpool/agent_pool.go
+++ b/services/scanner/agentpool/agent_pool.go
@@ -495,7 +495,7 @@ func (ap *AgentPool) updateAgentsOrFindMissing(latestVersions messaging.AgentPay
 				if !agent.Config().Equal(agentCfg) {
 					updatedAgents = append(updatedAgents, agent.Config())
 				}
-				agent.SetShardConfig(agentCfg)
+				agent.UpdateConfig(agentCfg)
 				agents = append(agents, agent)
 				return nil
 			},

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -697,11 +697,12 @@ func (agent *Agent) ShouldProcessAlert(event *protocol.AlertEvent) bool {
 	return isOnThisShard
 }
 
-func (agent *Agent) SetShardConfig(cfg config.AgentConfig) {
+func (agent *Agent) UpdateConfig(cfg config.AgentConfig) {
 	agent.mu.Lock()
 	defer agent.mu.Unlock()
 
 	agent.config.ShardConfig = cfg.ShardConfig
+	agent.config.Manifest = cfg.Manifest
 }
 
 func (agent *Agent) IsSharded() bool {


### PR DESCRIPTION
Bot version update handler wasn't updating the manifest of a deployed bot, which causes scan nodes to submit incorrect bot manifest information for the alert, even though it is executing the correct manifest version.

Sets `AgentConfig.Manifest` on version updates