### PR TITLE
Remove subscriptions from nuked bots

### DIFF
--- a/services/scanner/agentpool/agent_pool_test.go
+++ b/services/scanner/agentpool/agent_pool_test.go
@@ -89,6 +89,7 @@ func (s *Suite) TestStartProcessStop() {
 	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsStatusAttached, gomock.Any())
 	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsActionRun, gomock.Any())
 	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsAlertSubscribe, gomock.Any())
+	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsAlertUnsubscribe, gomock.Any())
 	s.msgClient.EXPECT().PublishProto(messaging.SubjectMetricAgent,gomock.Any())
 	s.r.NoError(s.ap.handleAgentVersionsUpdate(agentPayload))
 


### PR DESCRIPTION
- Registry sends the new list with `messaging.SubjectAgentsVersionsLatest`
  - agent pool handler processes the message, then updates `ap.agents`
    - sends `messaging.SubjectAgentsActionStop`, supervisor kills the container
      - supervisor sends `messaging.SubjectAgentsStatusStopped` with a list of stopped bots
        - agent pool iterates `ap.agents`, calls agent.Close for matching agent and removes subscriptions for that agent

The problem is that when agent pool updated the ap.agents in step 2, there won't be any matches at step 5.

We should remove subscriptions for any `agentsToStop` immediately at version update handler


Effects:
- combiner feed will continue fetching alerts for the nuked bot
- there will be public API proxy metrics because the feed keeps fetching alerts even though there are no assigned bots