### PR TITLE
Unblock poolagent.Agent's mutex and avoid hangs

### DIFF
--- a/services/scanner/agentpool/agent_pool.go
+++ b/services/scanner/agentpool/agent_pool.go
@@ -526,7 +526,7 @@ func (ap *AgentPool) findMissingAgentsInLatestVersions(latestVersions messaging.
 				break
 			}
 		}
-		
+
 		if !found {
 			_ = agent.Close()
 			agentsToStop = append(agentsToStop, cfg)


### PR DESCRIPTION
After some debugging, it appeared that `handleAgentVersionsUpdate` was not releasing the mutex. This was due to the bot calling logic in `poolagent` package grabbing the `Agent`s mutex. When that is grabbed and if the bot request lags, this causes a hang in other goroutines. This is the potential root cause for two issues:
- problem in bot deployments/updates
- input backpressure and block number lag