### PR TITLE
Improve bot initialization

### DIFF
--- a/services/scanner/agentpool/agent_pool.go
+++ b/services/scanner/agentpool/agent_pool.go
@@ -148,7 +148,7 @@ func (ap *AgentPool) SendEvaluateTxRequest(req *protocol.EvaluateTxRequest) {
 	}
 	var metricsList []*protocol.AgentMetric
 	for _, agent := range agents {
-		if !agent.IsReady() || !agent.ShouldProcessBlock(req.Event.Block.BlockNumber) {
+		if !agent.IsInitialized() || !agent.ShouldProcessBlock(req.Event.Block.BlockNumber) {
 			continue
 		}
 		lg.WithFields(log.Fields{
@@ -429,8 +429,8 @@ func (ap *AgentPool) handleStatusRunning(payload messaging.AgentPayload) error {
 				agent.SetClient(c)
 
 				go agent.Initialize()
-
 				agent.StartProcessing()
+				agent.SetReady()
 
 				logger.WithField("image", agent.Config().Image).Info("attached")
 				agentsReady = append(agentsReady, agent.Config())

--- a/services/scanner/agentpool/agent_pool.go
+++ b/services/scanner/agentpool/agent_pool.go
@@ -212,7 +212,7 @@ func (ap *AgentPool) SendEvaluateBlockRequest(req *protocol.EvaluateBlockRequest
 
 	var metricsList []*protocol.AgentMetric
 	for _, agent := range agents {
-		if !agent.IsReady() || !agent.ShouldProcessBlock(req.Event.BlockNumber) {
+		if !agent.IsInitialized() || !agent.ShouldProcessBlock(req.Event.BlockNumber) {
 			continue
 		}
 
@@ -293,7 +293,7 @@ func (ap *AgentPool) SendEvaluateAlertRequest(req *protocol.EvaluateAlertRequest
 			continue
 		}
 
-		if !agent.IsReady() {
+		if !agent.IsInitialized() {
 			continue
 		}
 		target = agent

--- a/services/scanner/agentpool/agent_pool.go
+++ b/services/scanner/agentpool/agent_pool.go
@@ -428,9 +428,17 @@ func (ap *AgentPool) handleStatusRunning(payload messaging.AgentPayload) error {
 				}
 
 				agent.SetClient(c)
+
+				err = agent.Initialize()
+				if err != nil {
+					log.WithField("agent", agent.Config().ID).WithError(err).Error("handleStatusRunning: error while initializing")
+					agentsToStop = append(agentsToStop, agent.Config())
+					removedSubscriptions = append(removedSubscriptions, agent.CombinerBotSubscriptions()...)
+					return nil
+				}
+
 				agent.SetReady()
 				agent.StartProcessing()
-				agent.WaitInitialization()
 
 				newSubscriptions = append(newSubscriptions, agent.CombinerBotSubscriptions()...)
 

--- a/services/scanner/agentpool/agent_pool_test.go
+++ b/services/scanner/agentpool/agent_pool_test.go
@@ -87,7 +87,6 @@ func (s *Suite) TestStartProcessStop() {
 	// Then a "run" action should be published
 	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsStatusAttached, gomock.Any())
 	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsActionRun, gomock.Any())
-	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsAlertSubscribe, gomock.Any())
 	s.msgClient.EXPECT().Publish(messaging.SubjectAgentsAlertUnsubscribe, gomock.Any())
 	s.msgClient.EXPECT().PublishProto(messaging.SubjectMetricAgent,gomock.Any())
 	s.r.NoError(s.ap.handleAgentVersionsUpdate(agentPayload))
@@ -98,7 +97,6 @@ func (s *Suite) TestStartProcessStop() {
 	// When the agent pool receives a message saying that the agent started to run
 	s.msgClient.EXPECT().PublishProto(messaging.SubjectMetricAgent,gomock.Any()).Times(2)
 	s.agentClient.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(nil, nil)
-	// <- s.ap.agents[0].Initialized()
 
 	s.r.NoError(s.ap.handleStatusRunning(agentPayload))
 	<- s.ap.agents[0].Initialized()

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -142,6 +142,7 @@ func New(ctx context.Context, agentCfg config.AgentConfig, msgClient clients.Mes
 		msgClient:           msgClient,
 		ready:               make(chan struct{}),
 		closed:              make(chan struct{}),
+		initialized:         make(chan struct{}),
 	}
 }
 

--- a/services/scanner/agentpool/poolagent/agent.go
+++ b/services/scanner/agentpool/poolagent/agent.go
@@ -301,13 +301,13 @@ func (agent *Agent) Initialize() {
 	ctx, cancel := context.WithTimeout(agent.ctx, DefaultAgentInitializeTimeout)
 	defer cancel()
 
-	// invoke Initialize method of the bot
+	// invoke initialize method of the bot
 	initializeResponse, err := agent.client.Initialize(ctx, &protocol.InitializeRequest{
 		AgentId:   agentConfig.ID,
 		ProxyHost: config.DockerJSONRPCProxyContainerName,
 	})
 
-	// it is not mandatory to implement a Initialize method, safe to skip
+	// it is not mandatory to implement a initialize method, safe to skip
 	if status.Code(err) == codes.Unimplemented {
 		logger.WithError(err).Info("Initialize() method not implemented in bot - safe to ignore")
 		agent.SetInitialized()


### PR DESCRIPTION
Instead of spawn-and-wait'ing bot initializations, lifecycle is now like the following:
- call go agent.Initialize()  at handleStatusRunning
- call SetInitialized() once initialization is completed
  - SendEvaluateXXX will skip if !agent.IsInitialized()
- call agent.Close() on init errors
  - at some point some routine will call ap.discardAgent(agent)  because the agent will be closed
    - pool will try deploying it again
- publishes the combiner subscription message in initialize method
  - it used happen in handleStatusRunning, but that thing won't have the alert config from the init response anymore