### PR TITLE
Scanner does not re deploy bots on deployment failures

### DIFF
--- a/services/supervisor/start_agent.go
+++ b/services/supervisor/start_agent.go
@@ -157,7 +157,7 @@ func (sup *SupervisorService) doStartAgent(ctx context.Context, agent config.Age
 	}
 	if err != nil {
 		logger.WithError(err).Error("failed to start agent")
-		sup.msgClient.Publish(messaging.SubjectAgentsStatusStopped, payload)
+		sup.msgClient.Publish(messaging.SubjectAgentsStatusStopped, messaging.AgentPayload{agent})
 		return
 	}
 

--- a/services/supervisor/start_agent.go
+++ b/services/supervisor/start_agent.go
@@ -157,6 +157,7 @@ func (sup *SupervisorService) doStartAgent(ctx context.Context, agent config.Age
 	}
 	if err != nil {
 		logger.WithError(err).Error("failed to start agent")
+		sup.msgClient.Publish(messaging.SubjectAgentsStatusStopped, payload)
 		return
 	}
 


### PR DESCRIPTION
Issue:
Pool is not aware of supervisor's bot deployment failures
Fix:
Emitting `agents.status.stopped` would inform the agent pool to remove the bot from the set of known bots, which will trigger a new deployment with the next `agents.versions.latest` message