### PR TITLE
Reduce the heat on docker image pulls

### DIFF
--- a/clients/docker/client.go
+++ b/clients/docker/client.go
@@ -892,7 +892,7 @@ func NewDockerClient(name string) (*dockerClient, error) {
 	}
 	return &dockerClient{
 		cli:     cli,
-		workers: workers.New(10),
+		workers: workers.New(1),
 		labels:  initLabels(name),
 	}, nil
 }
@@ -908,7 +908,7 @@ func NewAuthDockerClient(name string, username, password string) (*dockerClient,
 	}
 	return &dockerClient{
 		cli:      cli,
-		workers:  workers.New(10),
+		workers:  workers.New(1),
 		username: username,
 		password: password,
 		labels:   initLabels(name),

--- a/services/components/containers/bot_client.go
+++ b/services/components/containers/bot_client.go
@@ -15,7 +15,7 @@ import (
 
 // Timeouts
 const (
-	BotPullTimeout  = time.Minute * 5
+	BotPullTimeout  = time.Minute * 10
 	BotStartTimeout = time.Minute * 5
 
 	ImagePullCooldownThreshold = 5

--- a/services/supervisor/services_test.go
+++ b/services/supervisor/services_test.go
@@ -112,6 +112,7 @@ func (s *Suite) SetupTest() {
 	supervisor.config.Config.ChainID = 1
 	supervisor.config.Config.AdvancedConfig.IPFSExperiment = true
 	supervisor.config.Config.InspectionConfig.InspectAtStartup = utils.BoolPtr(false)
+	supervisor.config.Config.AgentLogsConfig.SendIntervalSeconds = 1
 	s.supervisor = supervisor
 }
 


### PR DESCRIPTION
- Reduce the concurrent image pull workers to 1.
- Increase the pull timeout to 10 minutes.