### PR TITLE
Improving bot processing metric flow

### DIFF
--- a/services/components/metrics/lifecycle.go
+++ b/services/components/metrics/lifecycle.go
@@ -67,6 +67,7 @@ type Lifecycle interface {
 
 	BotError(metricName string, err error, botID ...string)
 	SystemError(metricName string, err error)
+	BotInvokeError(componentName string, err error, botID ...string)
 
 	SystemStatus(metricName string, details string)
 }
@@ -164,6 +165,9 @@ func (lc *lifecycle) FailureTooManyErrs(err error, botConfigs ...config.AgentCon
 
 func (lc *lifecycle) BotError(metricName string, err error, botIDs ...string) {
 	SendAgentMetrics(lc.msgClient, fromBotIDs(fmt.Sprintf("agent.error.%s", metricName), err.Error(), botIDs))
+}
+func (lc *lifecycle) BotInvokeError(componentName string, err error, botIDs ...string) {
+	SendAgentMetrics(lc.msgClient, fromBotIDs(fmt.Sprintf("%s.error", componentName), err.Error(), botIDs))
 }
 
 func (lc *lifecycle) SystemError(metricName string, err error) {

--- a/services/components/metrics/mocks/mock_lifecycle.go
+++ b/services/components/metrics/mocks/mock_lifecycle.go
@@ -108,6 +108,23 @@ func (mr *MockLifecycleMockRecorder) BotError(metricName, err interface{}, botID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BotError", reflect.TypeOf((*MockLifecycle)(nil).BotError), varargs...)
 }
 
+// BotInvokeError mocks base method.
+func (m *MockLifecycle) BotInvokeError(componentName string, err error, botID ...string) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{componentName, err}
+	for _, a := range botID {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "BotInvokeError", varargs...)
+}
+
+// BotInvokeError indicates an expected call of BotInvokeError.
+func (mr *MockLifecycleMockRecorder) BotInvokeError(componentName, err interface{}, botID ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{componentName, err}, botID...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BotInvokeError", reflect.TypeOf((*MockLifecycle)(nil).BotInvokeError), varargs...)
+}
+
 // ClientClose mocks base method.
 func (m *MockLifecycle) ClientClose(arg0 ...config.AgentConfig) {
 	m.ctrl.T.Helper()

--- a/services/jwt-provider/api_test.go
+++ b/services/jwt-provider/api_test.go
@@ -40,7 +40,7 @@ func TestHandleJwtRequest(t *testing.T) {
 			},
 			mockFunc: func(mockProvider *mock_provider.MockJWTProvider) {
 				// Define the behavior for successful case
-				mockProvider.EXPECT().CreateJWT(gomock.Any(), gomock.Any(), gomock.Any()).Return("mockJWT", nil)
+				mockProvider.EXPECT().CreateJWTFromIP(gomock.Any(), gomock.Any(), gomock.Any()).Return("mockJWT", nil)
 			},
 			expectedHTTPCode: http.StatusOK,
 			expectedResponse: `{"token":"mockJWT"}`,
@@ -85,7 +85,7 @@ func TestHandleJwtRequest(t *testing.T) {
 			},
 			mockFunc: func(mockProvider *mock_provider.MockJWTProvider) {
 				// Define the behavior to make CreateJWTFromIP return ErrCannotFindBotForIP
-				mockProvider.EXPECT().CreateJWT(gomock.Any(), gomock.Any(), gomock.Any()).Return("", provider.ErrCannotFindBotForIP)
+				mockProvider.EXPECT().CreateJWTFromIP(gomock.Any(), gomock.Any(), gomock.Any()).Return("", provider.ErrCannotFindBotForIP)
 			},
 			expectedHTTPCode: http.StatusForbidden,
 			expectedResponse: "can't find bot id from request source 127.0.0.1, err: cannot find bot for ip",

--- a/services/jwt-provider/provider/mocks/mock_jwt.go
+++ b/services/jwt-provider/provider/mocks/mock_jwt.go
@@ -34,7 +34,7 @@ func (m *MockJWTProvider) EXPECT() *MockJWTProviderMockRecorder {
 	return m.recorder
 }
 
-// CreateJWT mocks base method.
+// CreateJWTFromIP mocks base method.
 func (m *MockJWTProvider) CreateJWTFromIP(ctx context.Context, ipAddress string, claims map[string]interface{}) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateJWTFromIP", ctx, ipAddress, claims)
@@ -43,8 +43,8 @@ func (m *MockJWTProvider) CreateJWTFromIP(ctx context.Context, ipAddress string,
 	return ret0, ret1
 }
 
-// CreateJWT indicates an expected call of CreateJWT.
-func (mr *MockJWTProviderMockRecorder) CreateJWT(ctx, ipAddress, claims interface{}) *gomock.Call {
+// CreateJWTFromIP indicates an expected call of CreateJWTFromIP.
+func (mr *MockJWTProviderMockRecorder) CreateJWTFromIP(ctx, ipAddress, claims interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJWTFromIP", reflect.TypeOf((*MockJWTProvider)(nil).CreateJWTFromIP), ctx, ipAddress, claims)
 }


### PR DESCRIPTION
- Aligning all processXXX methods
Due to a difference in error handling, block/tx processors aren't submitting `*.request` and `*.latency` metrics when there are invocation errors

- Starts submitting error metrics for invocation errors
This is different from `*.error` metrics we have right now. Instead of having error metrics only when there is a client-side error (ie. exceptions, error responses), nodes will emit metrics for invocation errors as well

Following is the request processing lifecycle metric flow:

```
- *.request
	- every attempt

- *.latency
	- every request has a latency

- *.success
	- response type success

- *.error
	- response type error
	- err != nil (invoke error)
		- details: err.Error()
```