### PR TITLE
Start utilizing health checks

### DIFF
--- a/clients/agentgrpc/client.go
+++ b/clients/agentgrpc/client.go
@@ -24,6 +24,7 @@ const (
 	MethodEvaluateTx    Method = "/network.forta.Agent/EvaluateTx"
 	MethodEvaluateBlock Method = "/network.forta.Agent/EvaluateBlock"
 	MethodEvaluateAlert Method = "/network.forta.Agent/EvaluateAlert"
+	MethodHealthCheck   Method = "/network.forta.Agent/HealthCheck"
 )
 
 // Client makes the gRPC requests to evaluate block and txs and receive results.

--- a/services/components/botio/bot_client_test.go
+++ b/services/components/botio/bot_client_test.go
@@ -3,6 +3,7 @@ package botio
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,8 +16,8 @@ import (
 	"github.com/forta-network/forta-node/config"
 	"github.com/forta-network/forta-node/services/components/botio/botreq"
 	mock_metrics "github.com/forta-network/forta-node/services/components/metrics/mocks"
-
 	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -235,4 +236,133 @@ func (s *BotClientSuite) TestInitialize_ValidationError() {
 	s.lifecycleMetrics.EXPECT().FailureInitializeValidate(gomock.Any(), s.botClient.configUnsafe)
 
 	s.botClient.Initialize()
+}
+
+func (s *BotClientSuite) TestHealthCheck() {
+	s.botGrpc.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(
+		&protocol.InitializeResponse{
+		}, nil,
+	).AnyTimes()
+
+	s.lifecycleMetrics.EXPECT().ClientDial(s.botClient.configUnsafe)
+	s.lifecycleMetrics.EXPECT().StatusAttached(s.botClient.configUnsafe)
+	s.lifecycleMetrics.EXPECT().StatusInitialized(s.botClient.configUnsafe)
+
+	s.botClient.Initialize()
+
+	<-s.botClient.Initialized()
+
+	ctx := context.Background()
+	resp := &protocol.HealthCheckResponse{
+		Status: protocol.HealthCheckResponse_SUCCESS,
+	}
+
+	// Mock HealthCheckAttempt() call
+	s.lifecycleMetrics.EXPECT().HealthCheckAttempt(gomock.Any())
+
+	// Use Do() to modify the request parameter
+	s.botGrpc.EXPECT().
+		Invoke(ctx, agentgrpc.MethodHealthCheck, gomock.Any(), gomock.AssignableToTypeOf(resp)).
+		Do(
+			func(ctx context.Context, method agentgrpc.Method, actualReq, resp interface{}, _ ...interface{}) {
+				// Modify the actualReq parameter
+				if resp, ok := resp.(*protocol.HealthCheckResponse); ok {
+					resp.Status = protocol.HealthCheckResponse_SUCCESS
+				}
+			},
+		).
+		Return(nil)
+
+	// Mock HealthCheckSuccess() call
+	s.lifecycleMetrics.EXPECT().HealthCheckSuccess(gomock.Any())
+
+	// Execute the method
+	result := s.botClient.doHealthCheck(ctx, logrus.WithField("y", "x"))
+
+	s.r.False(result, "Expected healthCheck to return false")
+}
+
+func (s *BotClientSuite) TestHealthCheck_WithError() {
+	s.botGrpc.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(
+		&protocol.InitializeResponse{
+		}, nil,
+	).AnyTimes()
+
+	s.lifecycleMetrics.EXPECT().ClientDial(s.botClient.configUnsafe)
+	s.lifecycleMetrics.EXPECT().StatusAttached(s.botClient.configUnsafe)
+	s.lifecycleMetrics.EXPECT().StatusInitialized(s.botClient.configUnsafe)
+
+	s.botClient.Initialize()
+
+	<-s.botClient.Initialized()
+
+	ctx := context.Background()
+	response := &protocol.HealthCheckResponse{
+		Status: protocol.HealthCheckResponse_ERROR,
+		Errors: []*protocol.Error{
+			{
+				Message: "Error 1",
+			},
+			{
+				Message: "Error 2",
+			},
+		},
+	}
+
+	// Mock HealthCheckAttempt() call
+	s.lifecycleMetrics.EXPECT().HealthCheckAttempt(gomock.Any())
+
+	// Use Do() to modify the request parameter
+	s.botGrpc.EXPECT().
+		Invoke(ctx, agentgrpc.MethodHealthCheck, gomock.Any(), gomock.AssignableToTypeOf(response)).
+		Do(
+			func(ctx context.Context, method agentgrpc.Method, actualReq, resp interface{}, _ ...interface{}) {
+				// Modify the actualReq parameter
+				if resp, ok := resp.(*protocol.HealthCheckResponse); ok {
+					resp.Status = response.Status
+					resp.Errors = response.Errors
+				}
+			},
+		).
+		Return(nil)
+
+	// Mock HealthCheckError() call
+	s.lifecycleMetrics.EXPECT().HealthCheckError(gomock.Any(), gomock.Any())
+
+	// Execute the method
+	result := s.botClient.doHealthCheck(ctx, logrus.WithField("y", "x"))
+
+	s.r.False(result, "Expected healthCheck to return false")
+}
+
+func (s *BotClientSuite) TestHealthCheck_WithInvokeError() {
+	s.botGrpc.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(
+		&protocol.InitializeResponse{
+		}, nil,
+	).AnyTimes()
+
+	s.lifecycleMetrics.EXPECT().ClientDial(s.botClient.configUnsafe)
+	s.lifecycleMetrics.EXPECT().StatusAttached(s.botClient.configUnsafe)
+	s.lifecycleMetrics.EXPECT().StatusInitialized(s.botClient.configUnsafe)
+
+	s.botClient.Initialize()
+
+	<-s.botClient.Initialized()
+
+	ctx := context.Background()
+
+	invokeErr := fmt.Errorf("failed to invoke method")
+	// Mock HealthCheckAttempt() call
+	s.lifecycleMetrics.EXPECT().HealthCheckAttempt(gomock.Any())
+
+	// Use Do() to modify the request parameter
+	s.botGrpc.EXPECT().Invoke(ctx, agentgrpc.MethodHealthCheck, gomock.Any(), gomock.Any()).Return(invokeErr)
+
+	// Mock HealthCheckError() call
+	s.lifecycleMetrics.EXPECT().HealthCheckError(gomock.Not(gomock.Nil()), gomock.Any())
+
+	// Execute the method
+	result := s.botClient.doHealthCheck(ctx, logrus.WithField("y", "x"))
+
+	s.r.False(result, "Expected healthCheck to return false")
 }

--- a/services/components/metrics/lifecycle.go
+++ b/services/components/metrics/lifecycle.go
@@ -36,6 +36,10 @@ const (
 	MetricFailureInitializeResponse = "agent.failure.initialize.response"
 	MetricFailureInitializeValidate = "agent.failure.initialize.validate"
 	MetricFailureTooManyErrs        = "agent.failure.too-many-errs"
+
+	MetricHealthCheckAttempt = "agent.health.attempt"
+	MetricHealthCheckSuccess = "agent.health.success"
+	MetricHealthCheckError   = "agent.health.error"
 )
 
 // Lifecycle creates lifecycle metrics. It is useful in
@@ -69,6 +73,10 @@ type Lifecycle interface {
 	SystemError(metricName string, err error)
 
 	SystemStatus(metricName string, details string)
+
+	HealthCheckAttempt(botConfigs ...config.AgentConfig)
+	HealthCheckSuccess(botConfigs ...config.AgentConfig)
+	HealthCheckError(err error, botConfigs ...config.AgentConfig)
 }
 
 type lifecycle struct {
@@ -172,6 +180,18 @@ func (lc *lifecycle) SystemError(metricName string, err error) {
 
 func (lc *lifecycle) SystemStatus(metricName string, details string) {
 	SendAgentMetrics(lc.msgClient, systemMetrics(fmt.Sprintf("system.status.%s", metricName), details))
+}
+
+func (lc *lifecycle) HealthCheckAttempt(botConfigs ...config.AgentConfig) {
+	SendAgentMetrics(lc.msgClient, fromBotConfigs(MetricHealthCheckAttempt, "", botConfigs))
+}
+
+func (lc *lifecycle) HealthCheckSuccess(botConfigs ...config.AgentConfig) {
+	SendAgentMetrics(lc.msgClient, fromBotConfigs(MetricHealthCheckSuccess, "", botConfigs))
+}
+
+func (lc *lifecycle) HealthCheckError(err error, botConfigs ...config.AgentConfig) {
+	SendAgentMetrics(lc.msgClient, fromBotConfigs(MetricHealthCheckError, err.Error(), botConfigs))
 }
 
 func fromBotSubscriptions(action string, subscriptions []domain.CombinerBotSubscription) (metrics []*protocol.AgentMetric) {

--- a/services/components/metrics/mocks/mock_lifecycle.go
+++ b/services/components/metrics/mocks/mock_lifecycle.go
@@ -276,6 +276,55 @@ func (mr *MockLifecycleMockRecorder) FailureTooManyErrs(arg0 interface{}, arg1 .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureTooManyErrs", reflect.TypeOf((*MockLifecycle)(nil).FailureTooManyErrs), varargs...)
 }
 
+// HealthCheckAttempt mocks base method.
+func (m *MockLifecycle) HealthCheckAttempt(botConfigs ...config.AgentConfig) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range botConfigs {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "HealthCheckAttempt", varargs...)
+}
+
+// HealthCheckAttempt indicates an expected call of HealthCheckAttempt.
+func (mr *MockLifecycleMockRecorder) HealthCheckAttempt(botConfigs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheckAttempt", reflect.TypeOf((*MockLifecycle)(nil).HealthCheckAttempt), botConfigs...)
+}
+
+// HealthCheckError mocks base method.
+func (m *MockLifecycle) HealthCheckError(err error, botConfigs ...config.AgentConfig) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{err}
+	for _, a := range botConfigs {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "HealthCheckError", varargs...)
+}
+
+// HealthCheckError indicates an expected call of HealthCheckError.
+func (mr *MockLifecycleMockRecorder) HealthCheckError(err interface{}, botConfigs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{err}, botConfigs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheckError", reflect.TypeOf((*MockLifecycle)(nil).HealthCheckError), varargs...)
+}
+
+// HealthCheckSuccess mocks base method.
+func (m *MockLifecycle) HealthCheckSuccess(botConfigs ...config.AgentConfig) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range botConfigs {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "HealthCheckSuccess", varargs...)
+}
+
+// HealthCheckSuccess indicates an expected call of HealthCheckSuccess.
+func (mr *MockLifecycleMockRecorder) HealthCheckSuccess(botConfigs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheckSuccess", reflect.TypeOf((*MockLifecycle)(nil).HealthCheckSuccess), botConfigs...)
+}
+
 // StatusActive mocks base method.
 func (m *MockLifecycle) StatusActive(arg0 ...config.AgentConfig) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- Invokes `HealthCheck` every 30 seconds
- Emits following lifecycle metrics:
1. `agent.health.attempt` for any healthcheck call
2. `agent.health.success` if the bot is healthy
3. `agent.health.error` if the bot is unhealthy, details for that metric conveys the errors