### PR TITLE
Add support for graceful bot shutdown

### DIFF
--- a/clients/docker/client.go
+++ b/clients/docker/client.go
@@ -33,6 +33,8 @@ const (
 	LabelFortaBotID                     = "network.forta.bot-id"
 
 	LabelFortaSettingsAgentLogsEnable = "network.forta.settings.agent-logs.enable"
+
+	BotShutdownTimeout = time.Minute
 )
 
 type dockerLabel struct {
@@ -595,8 +597,8 @@ func (d *dockerClient) InterruptContainer(ctx context.Context, id string) error 
 }
 
 // TerminateContainer stops a container by sending an termination signal.
-func (d *dockerClient) TerminateContainer(ctx context.Context, id string) error {
-	return d.stopContainer(ctx, id, "SIGTERM")
+func (d *dockerClient) TerminateContainer(ctx context.Context, id string, timeout *time.Duration) error {
+	return d.cli.ContainerStop(ctx, id, timeout)
 }
 
 // TerminateContainer stops a container by sending an termination signal.
@@ -605,6 +607,7 @@ func (d *dockerClient) stopContainer(ctx context.Context, containerID, signal st
 		"id":     containerID,
 		"signal": signal,
 	}).Infof("stopping container")
+
 	err := d.cli.ContainerKill(ctx, containerID, signal)
 	if err == nil {
 		return nil

--- a/clients/docker/client.go
+++ b/clients/docker/client.go
@@ -33,8 +33,6 @@ const (
 	LabelFortaBotID                     = "network.forta.bot-id"
 
 	LabelFortaSettingsAgentLogsEnable = "network.forta.settings.agent-logs.enable"
-
-	BotShutdownTimeout = time.Minute
 )
 
 type dockerLabel struct {
@@ -597,16 +595,23 @@ func (d *dockerClient) InterruptContainer(ctx context.Context, id string) error 
 }
 
 // TerminateContainer stops a container by sending an termination signal.
-func (d *dockerClient) TerminateContainer(ctx context.Context, id string, timeout *time.Duration) error {
+func (d *dockerClient) TerminateContainer(ctx context.Context, id string) error {
+	return d.stopContainer(ctx, id, "SIGTERM")
+}
+
+// ShutdownContainer stops a container by sending a termination signal and waits until either container exits or context cancels.
+func (d *dockerClient) ShutdownContainer(ctx context.Context, id string, timeout *time.Duration) error {
 	return d.cli.ContainerStop(ctx, id, timeout)
 }
 
 // TerminateContainer stops a container by sending an termination signal.
 func (d *dockerClient) stopContainer(ctx context.Context, containerID, signal string) error {
-	log.WithFields(log.Fields{
-		"id":     containerID,
-		"signal": signal,
-	}).Infof("stopping container")
+	log.WithFields(
+		log.Fields{
+			"id":     containerID,
+			"signal": signal,
+		},
+	).Infof("stopping container")
 
 	err := d.cli.ContainerKill(ctx, containerID, signal)
 	if err == nil {

--- a/clients/interfaces.go
+++ b/clients/interfaces.go
@@ -32,7 +32,8 @@ type DockerClient interface {
 	StartContainer(ctx context.Context, config docker.ContainerConfig) (*docker.Container, error)
 	StopContainer(ctx context.Context, id string) error
 	InterruptContainer(ctx context.Context, id string) error
-	TerminateContainer(ctx context.Context, id string, timeout *time.Duration) error
+	TerminateContainer(ctx context.Context, id string) error
+	ShutdownContainer(ctx context.Context, id string, timeout *time.Duration) error
 	RemoveContainer(ctx context.Context, containerID string) error
 	WaitContainerExit(ctx context.Context, id string) error
 	WaitContainerStart(ctx context.Context, id string) error

--- a/clients/interfaces.go
+++ b/clients/interfaces.go
@@ -32,7 +32,7 @@ type DockerClient interface {
 	StartContainer(ctx context.Context, config docker.ContainerConfig) (*docker.Container, error)
 	StopContainer(ctx context.Context, id string) error
 	InterruptContainer(ctx context.Context, id string) error
-	TerminateContainer(ctx context.Context, id string) error
+	TerminateContainer(ctx context.Context, id string, timeout *time.Duration) error
 	RemoveContainer(ctx context.Context, containerID string) error
 	WaitContainerExit(ctx context.Context, id string) error
 	WaitContainerStart(ctx context.Context, id string) error

--- a/clients/mocks/mock_clients.go
+++ b/clients/mocks/mock_clients.go
@@ -415,17 +415,17 @@ func (mr *MockDockerClientMockRecorder) StopContainer(ctx, id interface{}) *gomo
 }
 
 // TerminateContainer mocks base method.
-func (m *MockDockerClient) TerminateContainer(ctx context.Context, id string) error {
+func (m *MockDockerClient) TerminateContainer(ctx context.Context, id string, timeout *time.Duration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TerminateContainer", ctx, id)
+	ret := m.ctrl.Call(m, "TerminateContainer", ctx, id, timeout)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TerminateContainer indicates an expected call of TerminateContainer.
-func (mr *MockDockerClientMockRecorder) TerminateContainer(ctx, id interface{}) *gomock.Call {
+func (mr *MockDockerClientMockRecorder) TerminateContainer(ctx, id, timeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateContainer", reflect.TypeOf((*MockDockerClient)(nil).TerminateContainer), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateContainer", reflect.TypeOf((*MockDockerClient)(nil).TerminateContainer), ctx, id, timeout)
 }
 
 // WaitContainerExit mocks base method.

--- a/clients/mocks/mock_clients.go
+++ b/clients/mocks/mock_clients.go
@@ -371,6 +371,20 @@ func (mr *MockDockerClientMockRecorder) SetImagePullCooldown(threshold, cooldown
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetImagePullCooldown", reflect.TypeOf((*MockDockerClient)(nil).SetImagePullCooldown), threshold, cooldownDuration)
 }
 
+// ShutdownContainer mocks base method.
+func (m *MockDockerClient) ShutdownContainer(ctx context.Context, id string, timeout *time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShutdownContainer", ctx, id, timeout)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ShutdownContainer indicates an expected call of ShutdownContainer.
+func (mr *MockDockerClientMockRecorder) ShutdownContainer(ctx, id, timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShutdownContainer", reflect.TypeOf((*MockDockerClient)(nil).ShutdownContainer), ctx, id, timeout)
+}
+
 // StartContainer mocks base method.
 func (m *MockDockerClient) StartContainer(ctx context.Context, config docker.ContainerConfig) (*docker.Container, error) {
 	m.ctrl.T.Helper()
@@ -415,17 +429,17 @@ func (mr *MockDockerClientMockRecorder) StopContainer(ctx, id interface{}) *gomo
 }
 
 // TerminateContainer mocks base method.
-func (m *MockDockerClient) TerminateContainer(ctx context.Context, id string, timeout *time.Duration) error {
+func (m *MockDockerClient) TerminateContainer(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TerminateContainer", ctx, id, timeout)
+	ret := m.ctrl.Call(m, "TerminateContainer", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TerminateContainer indicates an expected call of TerminateContainer.
-func (mr *MockDockerClientMockRecorder) TerminateContainer(ctx, id, timeout interface{}) *gomock.Call {
+func (mr *MockDockerClientMockRecorder) TerminateContainer(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateContainer", reflect.TypeOf((*MockDockerClient)(nil).TerminateContainer), ctx, id, timeout)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateContainer", reflect.TypeOf((*MockDockerClient)(nil).TerminateContainer), ctx, id)
 }
 
 // WaitContainerExit mocks base method.

--- a/services/components/containers/bot_client.go
+++ b/services/components/containers/bot_client.go
@@ -167,7 +167,7 @@ func (bc *botClient) TearDownBot(ctx context.Context, containerName string, remo
 
 	timeout := BotShutdownTimeout
 
-	if err := bc.client.TerminateContainer(terminateCtx, container.ID, &timeout); err != nil {
+	if err := bc.client.ShutdownContainer(terminateCtx, container.ID, &timeout); err != nil {
 		log.WithFields(
 			log.Fields{
 				"containerId":   container.ID,

--- a/services/components/containers/bot_client_test.go
+++ b/services/components/containers/bot_client_test.go
@@ -150,6 +150,8 @@ func (s *BotClientTestSuite) TestTearDownBot() {
 		}, nil)
 		s.client.EXPECT().DetachNetwork(gomock.Any(), testContainerID, botConfig.ContainerName()).Return(testErr)
 	}
+	timeout := BotShutdownTimeout
+	s.client.EXPECT().TerminateContainer(gomock.Any(), testContainerID2, &timeout).Return(testErr)
 	s.client.EXPECT().RemoveContainer(gomock.Any(), testContainerID2).Return(testErr)
 	s.client.EXPECT().RemoveNetworkByName(gomock.Any(), botConfig.ContainerName()).Return(testErr)
 	s.client.EXPECT().RemoveImage(gomock.Any(), testImageRef).Return(testErr)

--- a/services/components/containers/bot_client_test.go
+++ b/services/components/containers/bot_client_test.go
@@ -151,7 +151,7 @@ func (s *BotClientTestSuite) TestTearDownBot() {
 		s.client.EXPECT().DetachNetwork(gomock.Any(), testContainerID, botConfig.ContainerName()).Return(testErr)
 	}
 	timeout := BotShutdownTimeout
-	s.client.EXPECT().TerminateContainer(gomock.Any(), testContainerID2, &timeout).Return(testErr)
+	s.client.EXPECT().ShutdownContainer(gomock.Any(), testContainerID2, &timeout).Return(testErr)
 	s.client.EXPECT().RemoveContainer(gomock.Any(), testContainerID2).Return(testErr)
 	s.client.EXPECT().RemoveNetworkByName(gomock.Any(), botConfig.ContainerName()).Return(testErr)
 	s.client.EXPECT().RemoveImage(gomock.Any(), testImageRef).Return(testErr)

--- a/services/runner/runner.go
+++ b/services/runner/runner.go
@@ -25,10 +25,6 @@ var (
 	ErrBadProxyAPI = fmt.Errorf("proxy api must be specified as http(s) when scan api is websocket")
 )
 
-const (
-	ContainerTerminateTimeout = time.Second * 30
-)
-
 // Runner receives and starts the latest updater and supervisor.
 type Runner struct {
 	ctx          context.Context

--- a/services/runner/runner.go
+++ b/services/runner/runner.go
@@ -25,6 +25,10 @@ var (
 	ErrBadProxyAPI = fmt.Errorf("proxy api must be specified as http(s) when scan api is websocket")
 )
 
+const (
+	ContainerTerminateTimeout = time.Second * 30
+)
+
 // Runner receives and starts the latest updater and supervisor.
 type Runner struct {
 	ctx          context.Context
@@ -146,7 +150,8 @@ func (runner *Runner) removeContainer(container *docker.Container) error {
 
 func (runner *Runner) removeContainerWithProps(name, id string) error {
 	logger := log.WithField("container", id).WithField("name", name)
-	if err := runner.dockerClient.TerminateContainer(context.Background(), id); err != nil {
+	timeout := ContainerTerminateTimeout
+	if err := runner.dockerClient.TerminateContainer(context.Background(), id, &timeout); err != nil {
 		logger.WithError(err).Error("error stopping container")
 	} else {
 		logger.Info("interrupted")

--- a/services/runner/runner.go
+++ b/services/runner/runner.go
@@ -150,8 +150,7 @@ func (runner *Runner) removeContainer(container *docker.Container) error {
 
 func (runner *Runner) removeContainerWithProps(name, id string) error {
 	logger := log.WithField("container", id).WithField("name", name)
-	timeout := ContainerTerminateTimeout
-	if err := runner.dockerClient.TerminateContainer(context.Background(), id, &timeout); err != nil {
+	if err := runner.dockerClient.TerminateContainer(context.Background(), id); err != nil {
 		logger.WithError(err).Error("error stopping container")
 	} else {
 		logger.Info("interrupted")


### PR DESCRIPTION
The method `TearDownBot` is evolved to support step 2:
Teardown lifecycle:
1. Detach networks
2. Send `SIGTERM` and wait until the container exits, with a maximum duration of 1 minute 
3. Remove container
4. Remove networks
5. Remove image
