### PR TITLE
Add subscription info to subscription action metrics

### DIFF
--- a/services/components/botio/bot_client.go
+++ b/services/components/botio/bot_client.go
@@ -474,7 +474,7 @@ func (bot *botClient) processTransaction(ctx context.Context, lg *log.Entry, req
 		// truncate findings
 		if len(resp.Findings) > MaxFindings {
 			dropped := len(resp.Findings) - MaxFindings
-			droppedMetric := metrics.CreateAgentMetric(botConfig, metrics.MetricFindingsDropped, float64(dropped))
+			droppedMetric := metrics.CreateAgentMetric(botConfig, metrics.MetricFindingsDropped, float64(dropped), "")
 			bot.msgClient.PublishProto(
 				messaging.SubjectMetricAgent,
 				&protocol.AgentMetricList{Metrics: []*protocol.AgentMetric{droppedMetric}},
@@ -541,7 +541,7 @@ func (bot *botClient) processBlock(ctx context.Context, lg *log.Entry, request *
 		if len(resp.Findings) > MaxFindings {
 			dropped := len(resp.Findings) - MaxFindings
 			droppedMetric := metrics.CreateAgentMetric(
-				botConfig, metrics.MetricFindingsDropped, float64(dropped),
+				botConfig, metrics.MetricFindingsDropped, float64(dropped), "",
 			)
 			bot.msgClient.PublishProto(
 				messaging.SubjectMetricAgent,
@@ -629,7 +629,7 @@ func (bot *botClient) processCombinationAlert(ctx context.Context, lg *log.Entry
 	// truncate findings
 	if len(resp.Findings) > MaxFindings {
 		dropped := len(resp.Findings) - MaxFindings
-		droppedMetric := metrics.CreateAgentMetric(botConfig, metrics.MetricFindingsDropped, float64(dropped))
+		droppedMetric := metrics.CreateAgentMetric(botConfig, metrics.MetricFindingsDropped, float64(dropped), "")
 		bot.msgClient.PublishProto(
 			messaging.SubjectMetricAgent, &protocol.AgentMetricList{Metrics: []*protocol.AgentMetric{droppedMetric}},
 		)

--- a/services/components/botio/sender.go
+++ b/services/components/botio/sender.go
@@ -115,7 +115,7 @@ func (rs *requestSender) SendEvaluateTxRequest(req *protocol.EvaluateTxRequest) 
 		}:
 		default: // do not try to send if the buffer is full
 			lg.WithField("bot", botConfig.ID).Debug("agent tx request buffer is full - skipping")
-			metricsList = append(metricsList, metrics.CreateAgentMetric(botConfig, metrics.MetricTxDrop, 1))
+			metricsList = append(metricsList, metrics.CreateAgentMetric(botConfig, metrics.MetricTxDrop, 1, ""))
 		}
 		lg.WithFields(log.Fields{
 			"bot":      botConfig.ID,
@@ -164,7 +164,7 @@ func (rs *requestSender) SendEvaluateBlockRequest(req *protocol.EvaluateBlockReq
 		}:
 		default: // do not try to send if the buffer is full
 			lg.WithField("bot", botConfig.ID).Warn("agent block request buffer is full - skipping")
-			metricsList = append(metricsList, metrics.CreateAgentMetric(botConfig, metrics.MetricBlockDrop, 1))
+			metricsList = append(metricsList, metrics.CreateAgentMetric(botConfig, metrics.MetricBlockDrop, 1, ""))
 		}
 		lg.WithFields(
 			log.Fields{
@@ -249,7 +249,7 @@ func (rs *requestSender) SendEvaluateAlertRequest(req *protocol.EvaluateAlertReq
 	}:
 	default: // do not try to send if the buffer is full
 		lg.WithField("bot", botConfig.ID).Warn("agent alert request buffer is full - skipping")
-		metricsList = append(metricsList, metrics.CreateAgentMetric(botConfig, metrics.MetricCombinerDrop, 1))
+		metricsList = append(metricsList, metrics.CreateAgentMetric(botConfig, metrics.MetricCombinerDrop, 1, ""))
 	}
 
 	lg.WithFields(

--- a/services/components/metrics/lifecycle.go
+++ b/services/components/metrics/lifecycle.go
@@ -176,7 +176,7 @@ func (lc *lifecycle) SystemStatus(metricName string, details string) {
 
 func fromBotSubscriptions(action string, subscriptions []domain.CombinerBotSubscription) (metrics []*protocol.AgentMetric) {
 	for _, botSub := range subscriptions {
-		metrics = append(metrics, CreateAgentMetric(config.AgentConfig{ID: botSub.Subscriber.BotID}, action, 1, botSub.Subscription.BotId))
+		metrics = append(metrics, CreateAgentMetric(config.AgentConfig{ID: botSub.Subscriber.BotID}, action, 1, fmt.Sprintf("botId=%s", botSub.Subscription.BotId)))
 	}
 	return
 }

--- a/services/components/metrics/lifecycle.go
+++ b/services/components/metrics/lifecycle.go
@@ -176,7 +176,7 @@ func (lc *lifecycle) SystemStatus(metricName string, details string) {
 
 func fromBotSubscriptions(action string, subscriptions []domain.CombinerBotSubscription) (metrics []*protocol.AgentMetric) {
 	for _, botSub := range subscriptions {
-		metrics = append(metrics, CreateAgentMetric(config.AgentConfig{ID: botSub.Subscriber.BotID}, action, 1))
+		metrics = append(metrics, CreateAgentMetric(config.AgentConfig{ID: botSub.Subscriber.BotID}, action, 1, botSub.Subscription.BotId))
 	}
 	return
 }

--- a/services/components/metrics/metrics.go
+++ b/services/components/metrics/metrics.go
@@ -52,13 +52,14 @@ func SendAgentMetrics(client clients.MessageClient, ms []*protocol.AgentMetric) 
 	}
 }
 
-func CreateAgentMetric(agt config.AgentConfig, metric string, value float64) *protocol.AgentMetric {
+func CreateAgentMetric(agt config.AgentConfig, metric string, value float64, details string) *protocol.AgentMetric {
 	return &protocol.AgentMetric{
 		AgentId:   agt.ID,
 		Timestamp: time.Now().Format(time.RFC3339),
 		Name:      metric,
 		Value:     value,
 		ShardId:   agt.ShardID(),
+		Details:   details,
 	}
 }
 


### PR DESCRIPTION
Adding subscribed bot id as detail for `agent.action.subscribe` and `agent.action.unsubscribe` metrics