### PR TITLE
Fix healthcheck evaluation

### DIFF
--- a/clients/agentgrpc/client.go
+++ b/clients/agentgrpc/client.go
@@ -113,7 +113,7 @@ func evaluateHealthCheckResult(invokeErr error, resp *protocol.HealthCheckRespon
 	var err error
 
 	// catch invocation errors
-	if invokeErr != nil && status.Code(err) != codes.Unimplemented {
+	if invokeErr != nil && status.Code(invokeErr) != codes.Unimplemented {
 		err = multierror.Append(err, invokeErr)
 	}
 


### PR DESCRIPTION
should check if `invokeErr` is `status.Unimplemented` instead of `err`