### PR TITLE
Add heartbeat bot to node

### DIFF
--- a/config/agents.go
+++ b/config/agents.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	AgentGrpcPort = "50051"
+	AgentGrpcPort  = "50051"
+	HeartbeatBotID = "0x37ce3df7facea4bd95619655347ffd66f50909d100fa74ae042f122a8b024c29"
 )
 
 type AgentConfig struct {

--- a/services/components/lifecycle/bot_manager.go
+++ b/services/components/lifecycle/bot_manager.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+	"github.com/forta-network/forta-node/store"
 	"strconv"
 	"time"
 
@@ -17,6 +18,9 @@ import (
 // Timeouts
 var (
 	botRemoveTimeout = time.Second * 5
+
+	heartbeatBotDuration     = time.Minute * 5
+	heartbeatBotLoadInterval = time.Hour
 )
 
 // BotLifecycleManager manages lifecycles of running bots.
@@ -29,11 +33,12 @@ type BotLifecycleManager interface {
 }
 
 type botLifecycleManager struct {
-	botRegistry      registry.BotRegistry
-	botClient        containers.BotClient
-	botPool          BotPoolUpdater
-	lifecycleMetrics metrics.Lifecycle
-	botMonitor       BotMonitor
+	botRegistry       registry.BotRegistry
+	botClient         containers.BotClient
+	botPool           BotPoolUpdater
+	lifecycleMetrics  metrics.Lifecycle
+	botMonitor        BotMonitor
+	lastHeartbeatLoad time.Time
 
 	runningBots []config.AgentConfig
 }
@@ -55,18 +60,40 @@ func NewManager(
 	}
 }
 
+func (blm *botLifecycleManager) setLastHeartbeatTime(t time.Time) {
+	blm.lastHeartbeatLoad = t
+}
+
+func (blm *botLifecycleManager) addHeartbeatBotIfDue(cfgs []config.AgentConfig) []config.AgentConfig {
+	// every hour, run the bot for 5 minutes, then treat it as removed
+	if time.Since(blm.lastHeartbeatLoad) > heartbeatBotLoadInterval || time.Since(blm.lastHeartbeatLoad) < heartbeatBotDuration {
+		hb, err := blm.botRegistry.LoadHeartbeatBot()
+		if err != nil && err != store.ErrLocalMode {
+			blm.lifecycleMetrics.SystemError("load.heartbeat.bot", err)
+		}
+		if hb != nil {
+			cfgs = append(cfgs, *hb)
+			blm.lastHeartbeatLoad = time.Now().UTC()
+		}
+	}
+	return cfgs
+}
+
 // ManageBots starts containers for assigned bots and stops the containers for unassigned
 // bots and lets other services know.
 func (blm *botLifecycleManager) ManageBots(ctx context.Context) error {
-	assignedBots, err := blm.botRegistry.LoadAssignedBots()
+	botsToRun, err := blm.botRegistry.LoadAssignedBots()
 	if err != nil {
 		blm.lifecycleMetrics.SystemError("load.assigned.bots", err)
 		return fmt.Errorf("failed to load assigned bots: %v", err)
 	}
-	blm.lifecycleMetrics.SystemStatus("load.assigned.bots", strconv.Itoa(len(assignedBots)))
+	blm.lifecycleMetrics.SystemStatus("load.assigned.bots", strconv.Itoa(len(botsToRun)))
+
+	// append the heartbeat bot if due to execute
+	botsToRun = blm.addHeartbeatBotIfDue(botsToRun)
 
 	// find the removed bots and remove them from the pool
-	removedBotConfigs := FindMissingBots(blm.runningBots, assignedBots)
+	removedBotConfigs := FindMissingBots(blm.runningBots, botsToRun)
 	if len(removedBotConfigs) > 0 {
 		if err := blm.botPool.RemoveBotsWithConfigs(removedBotConfigs); err != nil {
 			log.WithError(err).Error("error removing bots")
@@ -89,7 +116,7 @@ func (blm *botLifecycleManager) ManageBots(ctx context.Context) error {
 	}
 
 	// find the bot containers to start
-	addedBotConfigs := FindExtraBots(blm.runningBots, assignedBots)
+	addedBotConfigs := FindExtraBots(blm.runningBots, botsToRun)
 
 	// then download all images concurrently
 	var downloadErrs []error
@@ -108,7 +135,7 @@ func (blm *botLifecycleManager) ManageBots(ctx context.Context) error {
 				"error": downloadErrs[i],
 			}).Error("bot image download failed - skipping launch")
 			// drop the bot from the list so it can be picked again next time
-			assignedBots = Drop(addedBotConfig, assignedBots)
+			botsToRun = Drop(addedBotConfig, botsToRun)
 			blm.lifecycleMetrics.FailurePull(downloadErrs[i], addedBotConfig)
 			continue
 		}
@@ -119,20 +146,20 @@ func (blm *botLifecycleManager) ManageBots(ctx context.Context) error {
 			log.WithError(err).WithField("container", addedBotConfig.ContainerName()).
 				Warn("failed to launch bot")
 			// drop the bot from the list so it can be picked again next time
-			assignedBots = Drop(addedBotConfig, assignedBots)
+			botsToRun = Drop(addedBotConfig, botsToRun)
 			blm.lifecycleMetrics.FailureLaunch(err, addedBotConfig)
 			continue
 		}
 	}
 
 	// then update the pool with latest bots
-	if err := blm.botPool.UpdateBotsWithLatestConfigs(assignedBots); err != nil {
+	if err := blm.botPool.UpdateBotsWithLatestConfigs(botsToRun); err != nil {
 		blm.lifecycleMetrics.SystemError("update.bots.with.latest.configs", err)
 	}
-	blm.lifecycleMetrics.StatusRunning(assignedBots...)
-	blm.botMonitor.MonitorBots(GetBotIDs(assignedBots))
+	blm.lifecycleMetrics.StatusRunning(botsToRun...)
+	blm.botMonitor.MonitorBots(GetBotIDs(botsToRun))
 
-	blm.runningBots = assignedBots
+	blm.runningBots = botsToRun
 	return nil
 }
 

--- a/services/components/lifecycle/lifecycle_test.go
+++ b/services/components/lifecycle/lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/forta-network/forta-core-go/protocol"
@@ -64,6 +65,14 @@ type LifecycleTestSuite struct {
 	suite.Suite
 }
 
+func (s *LifecycleTestSuite) DisableHeartbeatBot() {
+	s.botManager.setLastHeartbeatTime(time.Now().UTC().Add(-10 * time.Minute))
+}
+
+func (s *LifecycleTestSuite) EnableHeartbeatBot() {
+	s.botManager.setLastHeartbeatTime(time.Time{})
+}
+
 func TestLifecycleTestSuite(t *testing.T) {
 	suite.Run(t, &LifecycleTestSuite{})
 }
@@ -96,6 +105,7 @@ func (s *LifecycleTestSuite) SetupTest() {
 func (s *LifecycleTestSuite) TestDownloadTimeout() {
 	s.T().Log("should redownload a bot if downloading times out")
 
+	s.DisableHeartbeatBot()
 	assigned := []config.AgentConfig{
 		{
 			ID:    testBotID1,
@@ -140,6 +150,7 @@ func (s *LifecycleTestSuite) TestDownloadTimeout() {
 func (s *LifecycleTestSuite) TestLaunchFailure() {
 	s.T().Log("should relaunch a bot if launching fails")
 
+	s.DisableHeartbeatBot()
 	assigned := []config.AgentConfig{
 		{
 			ID:    testBotID1,
@@ -185,6 +196,7 @@ func (s *LifecycleTestSuite) TestLaunchFailure() {
 func (s *LifecycleTestSuite) TestDialFailure() {
 	s.T().Log("should not reload or redial a bot if dialing finally fails")
 
+	s.DisableHeartbeatBot()
 	assigned := []config.AgentConfig{
 		{
 			ID:    testBotID1,
@@ -214,6 +226,7 @@ func (s *LifecycleTestSuite) TestDialFailure() {
 func (s *LifecycleTestSuite) TestInitializeFailure() {
 	s.T().Log("should reconnect to a bot if initialization finally fails")
 
+	s.DisableHeartbeatBot()
 	assigned := []config.AgentConfig{
 		{
 			ID:    testBotID1,
@@ -259,6 +272,7 @@ func (s *LifecycleTestSuite) TestInitializeFailure() {
 func (s *LifecycleTestSuite) TestExitedRestarted() {
 	s.T().Log("should restart and reconnect to exited bots")
 
+	s.DisableHeartbeatBot()
 	assigned := []config.AgentConfig{
 		{
 			ID:    testBotID1,
@@ -323,6 +337,7 @@ func (s *LifecycleTestSuite) TestExitedRestarted() {
 func (s *LifecycleTestSuite) TestInactiveRestarted() {
 	s.T().Log("should restart and reconnect to the inactive and exited bots")
 
+	s.DisableHeartbeatBot()
 	assigned := []config.AgentConfig{
 		{
 			ID:    testBotID1,
@@ -383,6 +398,7 @@ func (s *LifecycleTestSuite) TestInactiveRestarted() {
 func (s *LifecycleTestSuite) TestUnassigned() {
 	s.T().Log("should tear down unassigned bots")
 
+	s.DisableHeartbeatBot()
 	assigned := []config.AgentConfig{
 		{
 			ID:    testBotID1,
@@ -425,9 +441,43 @@ func (s *LifecycleTestSuite) TestUnassigned() {
 	<-createdBotClient.Closed()
 }
 
+func (s *LifecycleTestSuite) TestHearbeatBotLoads() {
+	s.T().Log("should load heartbeat bot")
+	s.EnableHeartbeatBot()
+
+	botsToRun := []config.AgentConfig{
+		*heartbeatBot,
+	}
+
+	// given that there is a new bot assignment
+	// and no new assignments after the first time
+	s.botRegistry.EXPECT().LoadAssignedBots().Return(nil, nil).Times(1)
+	s.botRegistry.EXPECT().LoadHeartbeatBot().Return(heartbeatBot, nil).Times(1)
+
+	s.lifecycleMetrics.EXPECT().SystemStatus("load.assigned.bots", "0").Times(1)
+
+	s.botContainers.EXPECT().EnsureBotImages(gomock.Any(), botsToRun).
+		Return([]error{nil}).Times(1)
+	s.botContainers.EXPECT().LaunchBot(gomock.Any(), botsToRun[0]).Return(nil).Times(1)
+	s.lifecycleMetrics.EXPECT().StatusRunning(botsToRun[0]).Times(1) // bot is running
+
+	s.lifecycleMetrics.EXPECT().ClientDial(botsToRun[0]).Times(1)
+	s.lifecycleMetrics.EXPECT().StatusAttached(botsToRun[0]).Times(1)
+	s.lifecycleMetrics.EXPECT().StatusInitialized(botsToRun[0]).Times(1)
+	s.dialer.EXPECT().DialBot(botsToRun[0]).Return(s.botGrpc, nil).Times(1)
+	s.botGrpc.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(&protocol.InitializeResponse{}, nil).
+		Times(1)
+
+	s.botMonitor.EXPECT().MonitorBots(GetBotIDs(botsToRun)).Times(1)
+
+	// when the bot manager manages the assigned bots over time
+	s.r.NoError(s.botManager.ManageBots(context.Background()))
+}
+
 func (s *LifecycleTestSuite) TestConfigUpdated() {
 	s.T().Log("should update bot config without tearing down")
 
+	s.DisableHeartbeatBot()
 	assigned := []config.AgentConfig{
 		{
 			ID:    testBotID1,

--- a/services/components/registry/mocks/mock_registry.go
+++ b/services/components/registry/mocks/mock_registry.go
@@ -64,6 +64,21 @@ func (mr *MockBotRegistryMockRecorder) LoadAssignedBots() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAssignedBots", reflect.TypeOf((*MockBotRegistry)(nil).LoadAssignedBots))
 }
 
+// LoadHeartbeatBot mocks base method.
+func (m *MockBotRegistry) LoadHeartbeatBot() (*config.AgentConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadHeartbeatBot")
+	ret0, _ := ret[0].(*config.AgentConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadHeartbeatBot indicates an expected call of LoadHeartbeatBot.
+func (mr *MockBotRegistryMockRecorder) LoadHeartbeatBot() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadHeartbeatBot", reflect.TypeOf((*MockBotRegistry)(nil).LoadHeartbeatBot))
+}
+
 // Name mocks base method.
 func (m *MockBotRegistry) Name() string {
 	m.ctrl.T.Helper()

--- a/services/components/registry/registry.go
+++ b/services/components/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/forta-network/forta-node/store"
@@ -15,6 +16,7 @@ import (
 // BotRegistry loads the latest bots from the registry store.
 type BotRegistry interface {
 	LoadAssignedBots() ([]config.AgentConfig, error)
+	LoadHeartbeatBot() (*config.AgentConfig, error)
 	health.Reporter
 }
 
@@ -52,6 +54,17 @@ func New(cfg config.Config, scannerAddress common.Address) (BotRegistry, error) 
 	}
 	service.registryStore = regStr
 	return service, nil
+}
+
+func (br *botRegistry) LoadHeartbeatBot() (*config.AgentConfig, error) {
+	ac, err := br.registryStore.FindAgentGlobally(config.HeartbeatBotID)
+	if err != nil {
+		return nil, err
+	}
+	if ac == nil {
+		return nil, errors.New("cannot not find heartbeat bot")
+	}
+	return ac, nil
 }
 
 // LoadAssignedBots returns the latest bot list for the running scanner.

--- a/services/components/registry/registry_test.go
+++ b/services/components/registry/registry_test.go
@@ -41,3 +41,20 @@ func TestLoadAssignedBots(t *testing.T) {
 	r.Error(err)
 	r.Nil(retCfgs)
 }
+
+func TestBotRegistry_LoadHeartbeatBot(t *testing.T) {
+	r := require.New(t)
+
+	ctrl := gomock.NewController(t)
+	regStore := mock_store.NewMockRegistryStore(ctrl)
+	botReg := &botRegistry{
+		scannerAddress: common.HexToAddress(utils.ZeroAddress),
+		registryStore:  regStore,
+	}
+	cfg := &config.AgentConfig{ID: config.HeartbeatBotID}
+	regStore.EXPECT().FindAgentGlobally(config.HeartbeatBotID).Return(cfg, nil)
+
+	res, err := botReg.LoadHeartbeatBot()
+	r.NoError(err)
+	r.Equal(config.HeartbeatBotID, res.ID)
+}

--- a/store/registry.go
+++ b/store/registry.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	errInvalidBot = errors.New("invalid bot")
+	ErrLocalMode  = errors.New("feature not available (private/local registry)")
 )
 
 const (
@@ -391,7 +392,7 @@ func (rs *privateRegistryStore) GetAgentsIfChanged(scanner string) ([]config.Age
 }
 
 func (rs *privateRegistryStore) FindAgentGlobally(agentID string) (*config.AgentConfig, error) {
-	return nil, errors.New("feature not available (private/local registry)")
+	return nil, ErrLocalMode
 }
 
 func (rs *privateRegistryStore) makePrivateModeAgentConfig(


### PR DESCRIPTION
- Runs a basic bot that emits no alerts every hour for 5 minutes 
- This gives the network an indication as to whether bots are successful