### PR TITLE
Make bot count in batch summary more accurate

### DIFF
--- a/clients/alert_sender.go
+++ b/clients/alert_sender.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/forta-network/forta-core-go/domain"
 	"github.com/forta-network/forta-core-go/protocol"
@@ -13,13 +14,15 @@ import (
 
 // AgentRoundTrip contains
 type AgentRoundTrip struct {
-	AgentConfig       config.AgentConfig
-	EvalBlockRequest  *protocol.EvaluateBlockRequest
-	EvalBlockResponse *protocol.EvaluateBlockResponse
-	EvalTxRequest     *protocol.EvaluateTxRequest
-	EvalTxResponse    *protocol.EvaluateTxResponse
-	EvalAlertRequest  *protocol.EvaluateAlertRequest
-	EvalAlertResponse *protocol.EvaluateAlertResponse
+	AgentConfig             config.AgentConfig
+	EvalBlockRequest        *protocol.EvaluateBlockRequest
+	EvalBlockResponse       *protocol.EvaluateBlockResponse
+	EvalTxRequest           *protocol.EvaluateTxRequest
+	EvalTxResponse          *protocol.EvaluateTxResponse
+	EvalAlertRequest        *protocol.EvaluateAlertRequest
+	EvalAlertResponse       *protocol.EvaluateAlertResponse
+	EvalHealthCheckRequest  *protocol.HealthCheckRequest
+	EvalHealthCheckResponse *protocol.HealthCheckResponse
 }
 
 type AlertSender interface {

--- a/services/components/botio/bot_client.go
+++ b/services/components/botio/bot_client.go
@@ -461,8 +461,10 @@ func (bot *botClient) processHealthChecks() {
 
 	<-bot.Initialized()
 
-	ticker := time.NewTicker(DefaultHealthCheckInterval)
+	bot.healthCheckRequests <- &botreq.HealthCheckRequest{Original: &protocol.HealthCheckRequest{}}
+	// trigger first healthcheck
 
+	ticker := time.NewTicker(DefaultHealthCheckInterval)
 	go func() {
 		for {
 			select {

--- a/services/components/botio/bot_client_test.go
+++ b/services/components/botio/bot_client_test.go
@@ -133,7 +133,7 @@ func (s *BotClientSuite) TestStartProcessStop() {
 	s.botGrpc.EXPECT().Invoke(
 		gomock.Any(), agentgrpc.MethodHealthCheck,
 		gomock.AssignableToTypeOf(&protocol.HealthCheckRequest{}), gomock.AssignableToTypeOf(&protocol.HealthCheckResponse{}),
-	).Return(nil)
+	).Return(nil).AnyTimes()
 	s.botClient.HealthCheckRequestCh() <- &botreq.HealthCheckRequest{
 		Original: healthCheckReq,
 	}
@@ -290,7 +290,7 @@ func (s *BotClientSuite) TestHealthCheck() {
 	s.botGrpc.EXPECT().Invoke(
 		gomock.Any(), agentgrpc.MethodHealthCheck,
 		gomock.AssignableToTypeOf(&protocol.HealthCheckRequest{}), gomock.AssignableToTypeOf(&protocol.HealthCheckResponse{}),
-	).Return(nil)
+	).Return(nil).AnyTimes()
 
 	// Execute the method
 	s.botClient.HealthCheckRequestCh() <- &botreq.HealthCheckRequest{
@@ -320,7 +320,7 @@ func (s *BotClientSuite) TestHealthCheck_WithError() {
 	s.botGrpc.EXPECT().Invoke(
 		gomock.Any(), agentgrpc.MethodHealthCheck,
 		gomock.AssignableToTypeOf(&protocol.HealthCheckRequest{}), gomock.AssignableToTypeOf(&protocol.HealthCheckResponse{}),
-	).Return(err)
+	).Return(err).AnyTimes()
 
 	// Execute the method
 	s.botClient.HealthCheckRequestCh() <- &botreq.HealthCheckRequest{

--- a/services/components/botio/botreq/request.go
+++ b/services/components/botio/botreq/request.go
@@ -18,3 +18,8 @@ type BlockRequest struct {
 type CombinationRequest struct {
 	Original *protocol.EvaluateAlertRequest
 }
+
+// HealthCheckRequest contains the request data.
+type HealthCheckRequest struct {
+	Original *protocol.HealthCheckRequest
+}

--- a/services/components/botio/botreq/result.go
+++ b/services/components/botio/botreq/result.go
@@ -14,6 +14,15 @@ type TxResult struct {
 	Timestamps  *domain.TrackingTimestamps
 }
 
+// HealthCheckResult contains request and response data.
+type HealthCheckResult struct {
+	AgentConfig config.AgentConfig
+	Request     *protocol.HealthCheckRequest
+	Response    *protocol.HealthCheckResponse
+	Timestamps  *domain.TrackingTimestamps
+	InvokeError error
+}
+
 // BlockResult contains request and response data.
 type BlockResult struct {
 	AgentConfig config.AgentConfig
@@ -35,6 +44,7 @@ type SendReceiveChannels struct {
 	Tx               chan *TxResult
 	Block            chan *BlockResult
 	CombinationAlert chan *CombinationAlertResult
+	HealthCheck      chan *HealthCheckResult
 }
 
 // MakeResultChannels makes the result channels and returns.
@@ -43,6 +53,7 @@ func MakeResultChannels() SendReceiveChannels {
 		Tx:               make(chan *TxResult),
 		Block:            make(chan *BlockResult),
 		CombinationAlert: make(chan *CombinationAlertResult),
+		HealthCheck:      make(chan *HealthCheckResult),
 	}
 }
 
@@ -52,6 +63,7 @@ func (src SendReceiveChannels) ReceiveOnly() ReceiveOnlyChannels {
 		Tx:               src.Tx,
 		Block:            src.Block,
 		CombinationAlert: src.CombinationAlert,
+		HealthCheck:      src.HealthCheck,
 	}
 }
 
@@ -61,6 +73,7 @@ func (src SendReceiveChannels) SendOnly() SendOnlyChannels {
 		Tx:               src.Tx,
 		Block:            src.Block,
 		CombinationAlert: src.CombinationAlert,
+		HealthCheck:      src.HealthCheck,
 	}
 }
 
@@ -69,6 +82,7 @@ type ReceiveOnlyChannels struct {
 	Tx               <-chan *TxResult
 	Block            <-chan *BlockResult
 	CombinationAlert <-chan *CombinationAlertResult
+	HealthCheck      <-chan *HealthCheckResult
 }
 
 // SendOnlyChannels has the bot result channels.
@@ -76,4 +90,5 @@ type SendOnlyChannels struct {
 	Tx               chan<- *TxResult
 	Block            chan<- *BlockResult
 	CombinationAlert chan<- *CombinationAlertResult
+	HealthCheck      chan<- *HealthCheckResult
 }

--- a/services/components/botio/mocks/mock_bot_client.go
+++ b/services/components/botio/mocks/mock_bot_client.go
@@ -121,6 +121,20 @@ func (mr *MockBotClientMockRecorder) Config() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockBotClient)(nil).Config))
 }
 
+// HealthCheckRequestCh mocks base method.
+func (m *MockBotClient) HealthCheckRequestCh() chan<- *botreq.HealthCheckRequest {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HealthCheckRequestCh")
+	ret0, _ := ret[0].(chan<- *botreq.HealthCheckRequest)
+	return ret0
+}
+
+// HealthCheckRequestCh indicates an expected call of HealthCheckRequestCh.
+func (mr *MockBotClientMockRecorder) HealthCheckRequestCh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheckRequestCh", reflect.TypeOf((*MockBotClient)(nil).HealthCheckRequestCh))
+}
+
 // Initialize mocks base method.
 func (m *MockBotClient) Initialize() {
 	m.ctrl.T.Helper()

--- a/services/components/lifecycle/lifecycle_test.go
+++ b/services/components/lifecycle/lifecycle_test.go
@@ -91,11 +91,6 @@ func (s *LifecycleTestSuite) SetupTest() {
 	s.resultChannels = botreq.MakeResultChannels()
 	s.botMonitor = mock_lifecycle.NewMockBotMonitor(ctrl)
 
-	// expecting any amount of health calls as we do not focus on testing it in this suite
-	s.lifecycleMetrics.EXPECT().HealthCheckAttempt(gomock.Any()).AnyTimes()
-	s.botGrpc.EXPECT().DoHealthCheck(gomock.Any()).AnyTimes()
-	s.lifecycleMetrics.EXPECT().HealthCheckSuccess(gomock.Any()).AnyTimes()
-
 	botClientFactory := botio.NewBotClientFactory(s.resultChannels.SendOnly(), s.msgClient, s.lifecycleMetrics, s.dialer)
 	s.botPool = NewBotPool(context.Background(), s.lifecycleMetrics, botClientFactory, 0)
 	s.botPool.waitInit = true // hack to make testing synchronous

--- a/services/components/metrics/lifecycle.go
+++ b/services/components/metrics/lifecycle.go
@@ -36,10 +36,6 @@ const (
 	MetricFailureInitializeResponse = "agent.failure.initialize.response"
 	MetricFailureInitializeValidate = "agent.failure.initialize.validate"
 	MetricFailureTooManyErrs        = "agent.failure.too-many-errs"
-
-	MetricHealthCheckAttempt = "agent.health.attempt"
-	MetricHealthCheckSuccess = "agent.health.success"
-	MetricHealthCheckError   = "agent.health.error"
 )
 
 // Lifecycle creates lifecycle metrics. It is useful in
@@ -73,10 +69,6 @@ type Lifecycle interface {
 	SystemError(metricName string, err error)
 
 	SystemStatus(metricName string, details string)
-
-	HealthCheckAttempt(botConfigs ...config.AgentConfig)
-	HealthCheckSuccess(botConfigs ...config.AgentConfig)
-	HealthCheckError(err error, botConfigs ...config.AgentConfig)
 }
 
 type lifecycle struct {
@@ -180,18 +172,6 @@ func (lc *lifecycle) SystemError(metricName string, err error) {
 
 func (lc *lifecycle) SystemStatus(metricName string, details string) {
 	SendAgentMetrics(lc.msgClient, systemMetrics(fmt.Sprintf("system.status.%s", metricName), details))
-}
-
-func (lc *lifecycle) HealthCheckAttempt(botConfigs ...config.AgentConfig) {
-	SendAgentMetrics(lc.msgClient, fromBotConfigs(MetricHealthCheckAttempt, "", botConfigs))
-}
-
-func (lc *lifecycle) HealthCheckSuccess(botConfigs ...config.AgentConfig) {
-	SendAgentMetrics(lc.msgClient, fromBotConfigs(MetricHealthCheckSuccess, "", botConfigs))
-}
-
-func (lc *lifecycle) HealthCheckError(err error, botConfigs ...config.AgentConfig) {
-	SendAgentMetrics(lc.msgClient, fromBotConfigs(MetricHealthCheckError, err.Error(), botConfigs))
 }
 
 func fromBotSubscriptions(action string, subscriptions []domain.CombinerBotSubscription) (metrics []*protocol.AgentMetric) {

--- a/services/components/metrics/mocks/mock_lifecycle.go
+++ b/services/components/metrics/mocks/mock_lifecycle.go
@@ -276,55 +276,6 @@ func (mr *MockLifecycleMockRecorder) FailureTooManyErrs(arg0 interface{}, arg1 .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureTooManyErrs", reflect.TypeOf((*MockLifecycle)(nil).FailureTooManyErrs), varargs...)
 }
 
-// HealthCheckAttempt mocks base method.
-func (m *MockLifecycle) HealthCheckAttempt(botConfigs ...config.AgentConfig) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{}
-	for _, a := range botConfigs {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "HealthCheckAttempt", varargs...)
-}
-
-// HealthCheckAttempt indicates an expected call of HealthCheckAttempt.
-func (mr *MockLifecycleMockRecorder) HealthCheckAttempt(botConfigs ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheckAttempt", reflect.TypeOf((*MockLifecycle)(nil).HealthCheckAttempt), botConfigs...)
-}
-
-// HealthCheckError mocks base method.
-func (m *MockLifecycle) HealthCheckError(err error, botConfigs ...config.AgentConfig) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{err}
-	for _, a := range botConfigs {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "HealthCheckError", varargs...)
-}
-
-// HealthCheckError indicates an expected call of HealthCheckError.
-func (mr *MockLifecycleMockRecorder) HealthCheckError(err interface{}, botConfigs ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{err}, botConfigs...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheckError", reflect.TypeOf((*MockLifecycle)(nil).HealthCheckError), varargs...)
-}
-
-// HealthCheckSuccess mocks base method.
-func (m *MockLifecycle) HealthCheckSuccess(botConfigs ...config.AgentConfig) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{}
-	for _, a := range botConfigs {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "HealthCheckSuccess", varargs...)
-}
-
-// HealthCheckSuccess indicates an expected call of HealthCheckSuccess.
-func (mr *MockLifecycleMockRecorder) HealthCheckSuccess(botConfigs ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheckSuccess", reflect.TypeOf((*MockLifecycle)(nil).HealthCheckSuccess), botConfigs...)
-}
-
 // StatusActive mocks base method.
 func (m *MockLifecycle) StatusActive(arg0 ...config.AgentConfig) {
 	m.ctrl.T.Helper()

--- a/services/scanner/health_check_analyzer.go
+++ b/services/scanner/health_check_analyzer.go
@@ -1,0 +1,83 @@
+package scanner
+
+import (
+	"context"
+
+	"github.com/forta-network/forta-core-go/clients/health"
+	"github.com/forta-network/forta-node/clients/messaging"
+	"github.com/forta-network/forta-node/services/components"
+	"github.com/forta-network/forta-node/services/components/botio/botreq"
+	"github.com/forta-network/forta-node/services/components/metrics"
+
+	"github.com/forta-network/forta-core-go/protocol"
+	"github.com/forta-network/forta-node/clients"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// HealthCheckAnalyzerService reads TX info, calls agents, and emits results
+type HealthCheckAnalyzerService struct {
+	ctx context.Context
+	cfg HealthCheckAnalyzerServiceConfig
+
+	lastInputActivity  health.TimeTracker
+	lastOutputActivity health.TimeTracker
+}
+
+type HealthCheckAnalyzerServiceConfig struct {
+	AlertSender clients.AlertSender
+	MsgClient   clients.MessageClient
+	components.BotProcessing
+}
+
+func (t *HealthCheckAnalyzerService) publishMetrics(result *botreq.HealthCheckResult) {
+	m := metrics.GetHealthCheckMetrics(result.AgentConfig, result.Response, result.Timestamps, result.InvokeError)
+	t.cfg.MsgClient.PublishProto(messaging.SubjectMetricAgent, &protocol.AgentMetricList{Metrics: m})
+}
+
+func (t *HealthCheckAnalyzerService) Start() error {
+	go func() {
+		for result := range t.cfg.BotProcessing.Results.HealthCheck {
+			rt := &clients.AgentRoundTrip{
+				AgentConfig:             result.AgentConfig,
+				EvalHealthCheckRequest:  result.Request,
+				EvalHealthCheckResponse: result.Response,
+			}
+
+			if err := t.cfg.AlertSender.NotifyWithoutAlert(
+				rt, result.Timestamps,
+			); err != nil {
+				log.WithError(err).Panic("failed to notify health check response")
+			}
+
+			t.publishMetrics(result)
+
+			t.lastOutputActivity.Set()
+		}
+	}()
+
+	return nil
+}
+
+func (t *HealthCheckAnalyzerService) Stop() error {
+	return nil
+}
+
+func (t *HealthCheckAnalyzerService) Name() string {
+	return "health-check-analyzer"
+}
+
+// Health implements the health.Reporter interface.
+func (t *HealthCheckAnalyzerService) Health() health.Reports {
+	return health.Reports{
+		t.lastInputActivity.GetReport("event.input.time"),
+		t.lastOutputActivity.GetReport("event.output.time"),
+	}
+}
+
+func NewHealthCheckAnalyzerService(ctx context.Context, cfg HealthCheckAnalyzerServiceConfig) (*HealthCheckAnalyzerService, error) {
+	return &HealthCheckAnalyzerService{
+		cfg: cfg,
+		ctx: ctx,
+	}, nil
+}

--- a/tests/e2e/e2e_forta_local_mode_test.go
+++ b/tests/e2e/e2e_forta_local_mode_test.go
@@ -276,9 +276,6 @@ func (s *Suite) runLocalModeAlertHandler(webhookURL, logFileName string, readAle
 	var healthCheckMetric *models.BotMetricSummary
 	for _, metric := range webhookAlerts.Metrics {
 		for _, summary := range metric.Metrics {
-			if strings.Contains(summary.Name, "agent.health") {
-				s.T().Logf("contains metric: %s", summary.Name)
-			}
 			if summary.Name == metrics.MetricHealthCheckSuccess {
 				healthCheckMetric = summary
 				break


### PR DESCRIPTION
scanner and batch publisher should be more aware of the healthcheck data so that the bot processing activity appears more accurately in batch summaries