### PR TITLE
fix scope of the 'err' variable

### DIFF
--- a/services/publisher/publisher.go
+++ b/services/publisher/publisher.go
@@ -292,20 +292,20 @@ func (pub *Publisher) publishNextBatch(batch *protocol.AlertBatch) (published bo
 		return false, err
 	}
 
-	if err != nil {
-		logger.WithError(err).Error("failed to sign cid")
-		return false, err
-	}
-
 	scannerAddr := pub.cfg.Key.Address.Hex()
 
 	var resp *domain.AlertBatchResponse
 	for i := 0; i < defaultBatchSendRetryTimes; i++ {
-		scannerJwt, err := security.CreateScannerJWT(
+		var scannerJwt string
+		scannerJwt, err = security.CreateScannerJWT(
 			pub.cfg.Key, map[string]interface{}{
 				"batch": cid,
 			},
 		)
+		if err != nil {
+			logger.WithError(err).Error("failed to sign cid")
+			return false, err
+		}
 		resp, err = pub.alertClient.PostBatch(&domain.AlertBatchRequest{
 			Scanner:            scannerAddr,
 			ChainID:            int64(batch.ChainId),


### PR DESCRIPTION
If post batch return an error its not visible after cycle and forta-scanner crashed with log

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1775867]

goroutine 215 [running]:
github.com/forta-network/forta-node/services/publisher.(*Publisher).publishNextBatch(0xc000026800, 0xc00c426000)
        /go/app/services/publisher/publisher.go:335 +0x1ee7
github.com/forta-network/forta-node/services/publisher.(*Publisher).publishBatches(0xc000026800)
        /go/app/services/publisher/publisher.go:490 +0x8d
created by github.com/forta-network/forta-node/services/publisher.(*Publisher).Start
        /go/app/services/publisher/publisher.go:809 +0x97
``` 
